### PR TITLE
T41 detections

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -198,6 +198,9 @@ std::vector<ConfigItem<bool>> CFG::getBoolItems()
         {"websocket.enabled", websocket.enabled, true, validateBool},
         {"websocket.ws_secured", websocket.ws_secured, true, validateBool},
         {"websocket.http_secured", websocket.http_secured, true, validateBool},
+        {"detection.enabled", detection.enabled, false, validateBool},
+        {"detection.show_labels", detection.show_labels, true, validateBool},
+        {"detection.show_confidence", detection.show_confidence, true, validateBool},
     };
 };
 
@@ -259,6 +262,7 @@ std::vector<ConfigItem<const char *>> CFG::getCharItems()
             std::string token(v);
             return token == "auto" || token.empty() || token.length() == WEBSOCKET_TOKEN_LENGTH;
         }},
+        {"detection.json_path", detection.json_path, "/tmp/detections.json", validateCharNotEmpty},
     };
 };
 
@@ -374,6 +378,9 @@ std::vector<ConfigItem<int>> CFG::getIntItems()
         {"stream2.fps", stream2.fps, 25, [](const int &v) { return v > 1 && v <= 30; }},
         {"websocket.port", websocket.port, 8089, validateInt65535},
         {"websocket.first_image_delay", websocket.first_image_delay, 100, validateInt65535},
+        {"detection.poll_interval_ms", detection.poll_interval_ms, 500, [](const int &v) { return v >= 100 && v <= 5000; }},
+        {"detection.line_width", detection.line_width, 2, [](const int &v) { return v >= 1 && v <= 10; }},
+        {"detection.max_boxes", detection.max_boxes, 10, [](const int &v) { return v >= 1 && v <= 50; }},
     };
 };
 
@@ -395,6 +402,10 @@ std::vector<ConfigItem<unsigned int>> CFG::getUintItems()
         {"stream1.osd.uptime_font_stroke_color", stream1.osd.uptime_font_stroke_color, 0xFF000000, validateOSDColor},
         {"stream1.osd.usertext_font_color", stream1.osd.usertext_font_color, 0xFFFFFFFF, validateOSDColor},
         {"stream1.osd.usertext_font_stroke_color", stream1.osd.usertext_font_stroke_color, 0xFF000000, validateOSDColor},
+        // Detection overlay colors (BGRA format)
+        {"detection.box_color", detection.box_color, 0xFF00FF00, validateOSDColor},  // Green
+        {"detection.text_color", detection.text_color, 0xFFFFFFFF, validateOSDColor},  // White
+        {"detection.text_stroke_color", detection.text_stroke_color, 0xFF000000, validateOSDColor},  // Black
     };
 };
 
@@ -786,6 +797,7 @@ std::vector<ConfigItem<float>> CFG::getFloatItems()
     return {
         {"rtsp.packet_loss_threshold", rtsp.packet_loss_threshold, 0.05f, [](const float &v) { return v >= 0.0f && v <= 1.0f; }},
         {"rtsp.bandwidth_margin", rtsp.bandwidth_margin, 1.2f, [](const float &v) { return v >= 1.0f && v <= 3.0f; }},
+        {"detection.min_confidence", detection.min_confidence, 0.5f, [](const float &v) { return v >= 0.0f && v <= 1.0f; }},
     };
 };
 

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -283,6 +283,19 @@ struct _websocket {
 struct _sysinfo {
     const char *cpu = nullptr;
 };
+struct _detection {
+    bool enabled;
+    const char *json_path;
+    int poll_interval_ms;
+    int line_width;
+    unsigned int box_color;
+    unsigned int text_color;
+    unsigned int text_stroke_color;
+    float min_confidence;
+    bool show_labels;
+    bool show_confidence;
+    int max_boxes;
+};
 
 class CFG {
 	public:
@@ -319,6 +332,7 @@ class CFG {
 		_motion motion{};
         _websocket websocket{};
         _sysinfo sysinfo{};
+        _detection detection{};
 
     template <typename T>
     T get(const std::string &name) {

--- a/src/Detection.cpp
+++ b/src/Detection.cpp
@@ -7,14 +7,15 @@
 
 extern std::shared_ptr<CFG> cfg;
 
+// Static buffer storage - allocated at compile time, no dynamic allocation
+uint8_t Detection::lineBuffers[MAX_LINE_REGIONS][MAX_LINE_BUFFER_SIZE];
+
 Detection::Detection(int osdGrp, uint16_t stream_width, uint16_t stream_height)
     : osdGrp(osdGrp), stream_width(stream_width), stream_height(stream_height),
       enabled(false), initialized(false), lastModTime(0), currentBoxCount(0)
 {
     for (int i = 0; i < MAX_LINE_REGIONS; i++) {
         lineHandles[i] = -1;
-        lineBuffers[i] = nullptr;
-        lineBufferSizes[i] = 0;
         lineActive[i] = false;
     }
 }
@@ -23,12 +24,15 @@ Detection::~Detection() { exit(); }
 
 int Detection::init()
 {
-    LOG_DEBUG("Detection::init() for osdGrp " << osdGrp << " - on-demand region creation");
-    // Don't pre-create OSD regions here - create them on-demand in drawBox()
-    // This avoids the crash from calling IMP_OSD_SetGrpRgnAttr without valid region data
+    LOG_DEBUG("Detection::init() for osdGrp " << osdGrp << " - lazy allocation mode");
+
+    // Don't pre-allocate buffers - allocate on-demand in drawBox()
+    // This avoids potential memory issues during startup
+    // Buffers will be allocated when first detection is drawn
+
     enabled = true;
     initialized = true;
-    LOG_INFO("Detection overlay initialized (on-demand regions), stream " << stream_width << "x" << stream_height);
+    LOG_INFO("Detection overlay initialized (lazy alloc), stream " << stream_width << "x" << stream_height);
     return 0;
 }
 
@@ -41,12 +45,7 @@ int Detection::exit()
             IMP_OSD_DestroyRgn(lineHandles[i]);
             lineHandles[i] = -1;
         }
-        // Only safe to free buffers after region is destroyed
-        if (lineBuffers[i]) {
-            free(lineBuffers[i]);
-            lineBuffers[i] = nullptr;
-        }
-        lineBufferSizes[i] = 0;
+        // Static buffers - no need to free
         lineActive[i] = false;
     }
     return 0;
@@ -206,31 +205,13 @@ void Detection::drawBox(int index, const DetectionBox& box)
         int num_pixels = w * h;
         int buf_size = num_pixels * 4;
 
-        // Reuse existing buffer if large enough, otherwise reallocate
-        // Note: We don't free the old buffer immediately because IMP may still be using it
-        // Also check for null buffer in case of previous allocation failure
-        if (lineBufferSizes[li] < buf_size || !lineBuffers[li]) {
-            // Need a larger buffer or buffer is null - free old one and allocate new
-            if (lineBuffers[li]) {
-                free(lineBuffers[li]);
-                lineBuffers[li] = nullptr;
-            }
-            lineBufferSizes[li] = 0;
-            lineBuffers[li] = (uint8_t*)malloc(buf_size);
-            if (!lineBuffers[li]) {
-                LOG_ERROR("Failed to allocate line buffer " << li << " size " << buf_size);
-                continue;
-            }
-            lineBufferSizes[li] = buf_size;
-        }
-
-        // Safety check - should never happen but prevents crash
-        if (!lineBuffers[li]) {
-            LOG_ERROR("Line buffer " << li << " is unexpectedly null");
+        // Check static buffer is large enough (should always be true with MAX_LINE_BUFFER_SIZE)
+        if (buf_size > MAX_LINE_BUFFER_SIZE) {
+            LOG_ERROR("Line buffer " << li << " size " << buf_size << " exceeds max " << MAX_LINE_BUFFER_SIZE);
             continue;
         }
 
-        // Fill buffer with solid color using 32-bit writes
+        // Fill static buffer with solid color using 32-bit writes
         uint32_t* buf32 = (uint32_t*)lineBuffers[li];
         for (int p = 0; p < num_pixels; p++) {
             buf32[p] = pixel;
@@ -241,7 +222,6 @@ void Detection::drawBox(int index, const DetectionBox& box)
             lineHandles[li] = IMP_OSD_CreateRgn(nullptr);
             if (lineHandles[li] < 0) {
                 LOG_ERROR("Failed to create OSD region for detection line " << li);
-                // Don't free buffer here - keep it for reuse
                 continue;
             }
             int ret = IMP_OSD_RegisterRgn(lineHandles[li], osdGrp, nullptr);
@@ -249,12 +229,6 @@ void Detection::drawBox(int index, const DetectionBox& box)
                 LOG_ERROR("Failed to register OSD region for detection line " << li);
                 IMP_OSD_DestroyRgn(lineHandles[li]);
                 lineHandles[li] = -1;
-                // Safe to free buffer since region was destroyed
-                if (lineBuffers[li]) {
-                    free(lineBuffers[li]);
-                    lineBuffers[li] = nullptr;
-                    lineBufferSizes[li] = 0;
-                }
                 continue;
             }
         }

--- a/src/Detection.cpp
+++ b/src/Detection.cpp
@@ -1,0 +1,344 @@
+#include "Detection.hpp"
+#include "Logger.hpp"
+#include "globals.hpp"
+#include <cstdio>
+#include <cstring>
+#include <sys/stat.h>
+
+extern std::shared_ptr<CFG> cfg;
+
+Detection::Detection(int osdGrp, uint16_t stream_width, uint16_t stream_height)
+    : osdGrp(osdGrp), stream_width(stream_width), stream_height(stream_height),
+      enabled(false), initialized(false), lastModTime(0), currentBoxCount(0)
+{
+    for (int i = 0; i < MAX_LINE_REGIONS; i++) {
+        lineHandles[i] = -1;
+        lineBuffers[i] = nullptr;
+        lineBufferSizes[i] = 0;
+        lineActive[i] = false;
+    }
+}
+
+Detection::~Detection() { exit(); }
+
+int Detection::init()
+{
+    LOG_DEBUG("Detection::init() for osdGrp " << osdGrp << " - on-demand region creation");
+    // Don't pre-create OSD regions here - create them on-demand in drawBox()
+    // This avoids the crash from calling IMP_OSD_SetGrpRgnAttr without valid region data
+    enabled = true;
+    initialized = true;
+    LOG_INFO("Detection overlay initialized (on-demand regions), stream " << stream_width << "x" << stream_height);
+    return 0;
+}
+
+int Detection::exit()
+{
+    LOG_DEBUG("Detection::exit()");
+    for (int i = 0; i < MAX_LINE_REGIONS; i++) {
+        if (lineHandles[i] >= 0) {
+            IMP_OSD_UnRegisterRgn(lineHandles[i], osdGrp);
+            IMP_OSD_DestroyRgn(lineHandles[i]);
+            lineHandles[i] = -1;
+        }
+        // Only safe to free buffers after region is destroyed
+        if (lineBuffers[i]) {
+            free(lineBuffers[i]);
+            lineBuffers[i] = nullptr;
+        }
+        lineBufferSizes[i] = 0;
+        lineActive[i] = false;
+    }
+    return 0;
+}
+
+bool Detection::isEnabled() const { return initialized && enabled; }
+void Detection::setEnabled(bool en) { enabled = en; if (!enabled && initialized) clearBoxes(); }
+
+bool Detection::parseDetectionJSON(const char* path, DetectionResult& result)
+{
+    FILE* f = fopen(path, "r");
+    if (!f) return false;
+    char buffer[4096];
+    size_t len = fread(buffer, 1, sizeof(buffer) - 1, f);
+    fclose(f);
+    if (len == 0) return false;
+    buffer[len] = '\0';
+
+    result.detections.clear();
+    result.count = 0;
+    result.inference_ms = 0;
+
+    // Use hardcoded limits to avoid accessing cfg in thread context
+    const int max_boxes = MAX_DETECTION_BOXES;
+    const float min_confidence = 0.5f;
+
+    char* p = strstr(buffer, "\"inference_ms\":");
+    if (p) result.inference_ms = atof(p + 15);
+    p = strstr(buffer, "\"count\":");
+    if (p) result.count = atoi(p + 8);
+
+    p = strstr(buffer, "\"detections\":[");
+    if (!p) return true;
+    p += 14;
+
+    while (*p && result.detections.size() < (size_t)max_boxes) {
+        char* objStart = strchr(p, '{');
+        if (!objStart) break;
+        char* objEnd = strchr(objStart, '}');
+        if (!objEnd) break;
+
+        DetectionBox box;
+        box.confidence = 0;
+        box.x1 = box.y1 = box.x2 = box.y2 = 0;
+
+        char* classPtr = strstr(objStart, "\"class\":\"");
+        if (classPtr && classPtr < objEnd) {
+            classPtr += 9;
+            char* classEnd = strchr(classPtr, '"');
+            if (classEnd && classEnd < objEnd)
+                box.class_name = std::string(classPtr, classEnd - classPtr);
+        }
+        char* confPtr = strstr(objStart, "\"conf\":");
+        if (confPtr && confPtr < objEnd) box.confidence = atof(confPtr + 7);
+
+        char* boxPtr = strstr(objStart, "\"box\":[");
+        if (boxPtr && boxPtr < objEnd) {
+            boxPtr += 7;
+            sscanf(boxPtr, "%f,%f,%f,%f", &box.x1, &box.y1, &box.x2, &box.y2);
+        }
+        if (box.confidence >= min_confidence)
+            result.detections.push_back(box);
+        p = objEnd + 1;
+    }
+    return true;
+}
+
+// Helper to hide a single line region (does NOT free buffer - IMP may still be using it)
+void Detection::hideLine(int lineIndex)
+{
+    if (lineIndex >= MAX_LINE_REGIONS || lineHandles[lineIndex] < 0) return;
+    if (lineActive[lineIndex]) {
+        IMPOSDGrpRgnAttr grpRgnAttr;
+        memset(&grpRgnAttr, 0, sizeof(IMPOSDGrpRgnAttr));
+        grpRgnAttr.show = 0;
+        IMP_OSD_SetGrpRgnAttr(lineHandles[lineIndex], osdGrp, &grpRgnAttr);
+        lineActive[lineIndex] = false;
+    }
+    // DO NOT free buffer here - IMP OSD may still be accessing it asynchronously
+    // Buffers are only freed in exit() after region is destroyed, or reused in drawBox()
+}
+
+// Draw a single detection box using 4 thin line regions (top, bottom, left, right)
+// This uses ~48KB max per box instead of ~8MB for a full rectangle
+void Detection::drawBox(int index, const DetectionBox& box)
+{
+    if (index >= MAX_DETECTION_BOXES) return;
+
+    int x1 = (int)(box.x1 * stream_width);
+    int y1 = (int)(box.y1 * stream_height);
+    int x2 = (int)(box.x2 * stream_width);
+    int y2 = (int)(box.y2 * stream_height);
+
+    // Clamp to valid screen coordinates
+    if (x1 < 0) x1 = 0;
+    if (y1 < 0) y1 = 0;
+    if (x2 >= stream_width) x2 = stream_width - 1;
+    if (y2 >= stream_height) y2 = stream_height - 1;
+
+    int box_width = x2 - x1;
+    int box_height = y2 - y1;
+
+    // Use hardcoded values to avoid cfg access issues in thread context
+    int lw = 2;  // line width
+    if (lw < 1) lw = 1;
+    if (lw > 10) lw = 10;
+
+    // Box must be larger than line width
+    if (box_width < lw * 2 || box_height < lw * 2) return;
+
+    // Green color in BGRA format: 0xFF00FF00
+    unsigned int color = 0xFF00FF00;
+    uint8_t cb = color & 0xFF;           // B = 0x00
+    uint8_t cg = (color >> 8) & 0xFF;    // G = 0xFF
+    uint8_t cr = (color >> 16) & 0xFF;   // R = 0x00
+    uint8_t ca = (color >> 24) & 0xFF;   // A = 0xFF
+
+    // Pre-compute the 32-bit BGRA pixel value for memset-style fill
+    uint32_t pixel = ((uint32_t)ca << 24) | ((uint32_t)cr << 16) | ((uint32_t)cg << 8) | cb;
+
+    // Line region indices: 0=top, 1=bottom, 2=left, 3=right
+    int baseIdx = index * LINES_PER_BOX;
+
+    // Define the 4 lines with safe coordinates
+    // Top line: full width at top
+    // Bottom line: full width at bottom
+    // Left line: only the middle portion (excluding corners already covered by top/bottom)
+    // Right line: only the middle portion
+    int inner_height = box_height - 2 * lw;
+    if (inner_height < 2) inner_height = 2;
+
+    struct { int x, y, w, h; } lines[4] = {
+        { x1, y1, box_width, lw },                           // top
+        { x1, y1 + box_height - lw, box_width, lw },         // bottom
+        { x1, y1 + lw, lw, inner_height },                   // left (between top and bottom)
+        { x1 + box_width - lw, y1 + lw, lw, inner_height }   // right (between top and bottom)
+    };
+
+    for (int l = 0; l < LINES_PER_BOX; l++) {
+        int li = baseIdx + l;
+        if (li >= MAX_LINE_REGIONS) continue;
+
+        int lx = lines[l].x;
+        int ly = lines[l].y;
+        int w = lines[l].w;
+        int h = lines[l].h;
+
+        // Skip invalid dimensions
+        if (w <= 0 || h <= 0) continue;
+
+        // Ensure even dimensions (IMP OSD requirement)
+        if (w % 2 != 0) w++;
+        if (h % 2 != 0) h++;
+        if (w < 2) w = 2;
+        if (h < 2) h = 2;
+
+        int num_pixels = w * h;
+        int buf_size = num_pixels * 4;
+
+        // Reuse existing buffer if large enough, otherwise reallocate
+        // Note: We don't free the old buffer immediately because IMP may still be using it
+        // Also check for null buffer in case of previous allocation failure
+        if (lineBufferSizes[li] < buf_size || !lineBuffers[li]) {
+            // Need a larger buffer or buffer is null - free old one and allocate new
+            if (lineBuffers[li]) {
+                free(lineBuffers[li]);
+                lineBuffers[li] = nullptr;
+            }
+            lineBufferSizes[li] = 0;
+            lineBuffers[li] = (uint8_t*)malloc(buf_size);
+            if (!lineBuffers[li]) {
+                LOG_ERROR("Failed to allocate line buffer " << li << " size " << buf_size);
+                continue;
+            }
+            lineBufferSizes[li] = buf_size;
+        }
+
+        // Safety check - should never happen but prevents crash
+        if (!lineBuffers[li]) {
+            LOG_ERROR("Line buffer " << li << " is unexpectedly null");
+            continue;
+        }
+
+        // Fill buffer with solid color using 32-bit writes
+        uint32_t* buf32 = (uint32_t*)lineBuffers[li];
+        for (int p = 0; p < num_pixels; p++) {
+            buf32[p] = pixel;
+        }
+
+        // Create region on-demand if it doesn't exist
+        if (lineHandles[li] < 0) {
+            lineHandles[li] = IMP_OSD_CreateRgn(nullptr);
+            if (lineHandles[li] < 0) {
+                LOG_ERROR("Failed to create OSD region for detection line " << li);
+                // Don't free buffer here - keep it for reuse
+                continue;
+            }
+            int ret = IMP_OSD_RegisterRgn(lineHandles[li], osdGrp, nullptr);
+            if (ret < 0) {
+                LOG_ERROR("Failed to register OSD region for detection line " << li);
+                IMP_OSD_DestroyRgn(lineHandles[li]);
+                lineHandles[li] = -1;
+                // Safe to free buffer since region was destroyed
+                if (lineBuffers[li]) {
+                    free(lineBuffers[li]);
+                    lineBuffers[li] = nullptr;
+                    lineBufferSizes[li] = 0;
+                }
+                continue;
+            }
+        }
+
+        // Set up region attributes with actual data FIRST
+        IMPOSDRgnAttr rgnAttr;
+        memset(&rgnAttr, 0, sizeof(IMPOSDRgnAttr));
+        rgnAttr.type = OSD_REG_PIC;
+        rgnAttr.fmt = PIX_FMT_BGRA;
+        rgnAttr.rect.p0.x = lx;
+        rgnAttr.rect.p0.y = ly;
+        rgnAttr.rect.p1.x = lx + w - 1;
+        rgnAttr.rect.p1.y = ly + h - 1;
+        rgnAttr.data.picData.pData = lineBuffers[li];
+
+        IMP_OSD_SetRgnAttr(lineHandles[li], &rgnAttr);
+
+        // THEN set group region attributes (show the region)
+        IMPOSDGrpRgnAttr grpRgnAttr;
+        memset(&grpRgnAttr, 0, sizeof(IMPOSDGrpRgnAttr));
+        grpRgnAttr.show = 1;
+        grpRgnAttr.layer = 5 + li;
+        grpRgnAttr.gAlphaEn = 1;
+        grpRgnAttr.fgAlhpa = 255;
+        grpRgnAttr.bgAlhpa = 0;
+        IMP_OSD_SetGrpRgnAttr(lineHandles[li], osdGrp, &grpRgnAttr);
+
+        lineActive[li] = true;
+    }
+}
+
+void Detection::clearBoxes()
+{
+    for (int i = 0; i < MAX_LINE_REGIONS; i++) {
+        hideLine(i);
+    }
+    currentBoxCount = 0;
+}
+
+void Detection::update()
+{
+    // Don't update if not initialized or not enabled
+    if (!initialized) return;
+
+    if (!isEnabled()) {
+        if (currentBoxCount > 0) clearBoxes();
+        return;
+    }
+
+    // Use hardcoded path to avoid any issues with cfg pointer
+    const char* json_path = "/tmp/detections.json";
+
+    struct stat st;
+    if (stat(json_path, &st) != 0) {
+        // File doesn't exist yet, clear boxes and return
+        if (currentBoxCount > 0) clearBoxes();
+        return;
+    }
+
+    // Skip if file hasn't changed
+    if (st.st_mtime == lastModTime) return;
+    lastModTime = st.st_mtime;
+
+    DetectionResult result;
+    if (!parseDetectionJSON(json_path, result)) return;
+
+    // Limit to max detection boxes
+    size_t numBoxes = result.detections.size();
+    if (numBoxes > MAX_DETECTION_BOXES) numBoxes = MAX_DETECTION_BOXES;
+
+    // Hide line regions for boxes that are no longer needed
+    for (int i = (int)numBoxes; i < currentBoxCount; i++) {
+        int baseIdx = i * LINES_PER_BOX;
+        for (int l = 0; l < LINES_PER_BOX; l++) {
+            if (baseIdx + l < MAX_LINE_REGIONS) {
+                hideLine(baseIdx + l);
+            }
+        }
+    }
+
+    // Draw active boxes
+    for (size_t i = 0; i < numBoxes; i++) {
+        drawBox((int)i, result.detections[i]);
+    }
+
+    currentBoxCount = (int)numBoxes;
+}

--- a/src/Detection.hpp
+++ b/src/Detection.hpp
@@ -12,6 +12,10 @@
 // 4 line regions per box: top, bottom, left, right
 #define LINES_PER_BOX 4
 #define MAX_LINE_REGIONS (MAX_DETECTION_BOXES * LINES_PER_BOX)
+// Fixed line width and max buffer size per line
+// Max line size: 1920 pixels * 4 bytes/pixel * 4 pixels wide = 30720 bytes
+#define DETECTION_LINE_WIDTH 4
+#define MAX_LINE_BUFFER_SIZE (1920 * DETECTION_LINE_WIDTH * 4)
 
 struct DetectionBox {
     float x1, y1, x2, y2;  // Normalized coordinates (0.0-1.0)
@@ -68,8 +72,8 @@ private:
 
     // OSD handles for line regions (4 per box: top, bottom, left, right)
     IMPRgnHandle lineHandles[MAX_LINE_REGIONS];
-    uint8_t* lineBuffers[MAX_LINE_REGIONS];
-    int lineBufferSizes[MAX_LINE_REGIONS];  // Track buffer sizes for reuse
+    // Static buffers - no dynamic allocation, IMP OSD can safely access these
+    static uint8_t lineBuffers[MAX_LINE_REGIONS][MAX_LINE_BUFFER_SIZE];
     bool lineActive[MAX_LINE_REGIONS];
 
     // Last file modification time to avoid unnecessary re-reads

--- a/src/Detection.hpp
+++ b/src/Detection.hpp
@@ -1,0 +1,83 @@
+#ifndef DETECTION_HPP
+#define DETECTION_HPP
+
+#include <vector>
+#include <string>
+#include <ctime>
+#include <imp/imp_osd.h>
+#include "Config.hpp"
+
+// Maximum number of detection boxes to display (keep low to avoid OSD region exhaustion)
+#define MAX_DETECTION_BOXES 4
+// 4 line regions per box: top, bottom, left, right
+#define LINES_PER_BOX 4
+#define MAX_LINE_REGIONS (MAX_DETECTION_BOXES * LINES_PER_BOX)
+
+struct DetectionBox {
+    float x1, y1, x2, y2;  // Normalized coordinates (0.0-1.0)
+    float confidence;
+    std::string class_name;
+};
+
+struct DetectionResult {
+    float inference_ms;
+    int count;
+    std::vector<DetectionBox> detections;
+    time_t last_modified;
+};
+
+class Detection {
+public:
+    Detection(int osdGrp, uint16_t stream_width, uint16_t stream_height);
+    ~Detection();
+
+    // Initialize OSD regions for detection boxes
+    int init();
+
+    // Clean up OSD regions
+    int exit();
+
+    // Update detection boxes from JSON file
+    void update();
+
+    // Check if detection is enabled
+    bool isEnabled() const;
+
+    // Set enabled state
+    void setEnabled(bool enabled);
+
+private:
+    // Parse JSON detection file
+    bool parseDetectionJSON(const char* path, DetectionResult& result);
+
+    // Draw a single detection box using 4 line regions (top, bottom, left, right)
+    void drawBox(int index, const DetectionBox& box);
+
+    // Clear all detection boxes
+    void clearBoxes();
+
+    // Hide a single line region
+    void hideLine(int lineIndex);
+
+    // Configuration
+    int osdGrp;
+    uint16_t stream_width;
+    uint16_t stream_height;
+    bool enabled;
+    bool initialized;  // Prevent update() before init() completes
+
+    // OSD handles for line regions (4 per box: top, bottom, left, right)
+    IMPRgnHandle lineHandles[MAX_LINE_REGIONS];
+    uint8_t* lineBuffers[MAX_LINE_REGIONS];
+    int lineBufferSizes[MAX_LINE_REGIONS];  // Track buffer sizes for reuse
+    bool lineActive[MAX_LINE_REGIONS];
+
+    // Last file modification time to avoid unnecessary re-reads
+    time_t lastModTime;
+
+    // Current detection count
+    int currentBoxCount;
+};
+
+#endif // DETECTION_HPP
+

--- a/src/IMPAudio.cpp
+++ b/src/IMPAudio.cpp
@@ -144,8 +144,14 @@ int IMPAudio::init()
     LOG_DEBUG_OR_ERROR(ret, "IMP_AI_Enable(" << devId << ")");
 
     IMPAudioIChnParam chnParam = {
-        .usrFrmDepth = 30, // frame buffer depth
+#if defined(PLATFORM_T40) || defined(PLATFORM_T41)
+        .usrFrmDepth = 30,
+        .aecChn = AUDIO_AEC_CHANNEL_FIRST_LEFT,  // T40/T41 require aecChn to be initialized
         .Rev = 0
+#else
+        .usrFrmDepth = 30,
+        .Rev = 0
+#endif
     };
 
     ret = IMP_AI_SetChnParam(devId, inChn, &chnParam);

--- a/src/IMPEncoder.cpp
+++ b/src/IMPEncoder.cpp
@@ -312,15 +312,18 @@ int IMPEncoder::init()
 
     initProfile();
 
+    ret = IMP_Encoder_CreateChn(encChn, &chnAttr);
+    LOG_DEBUG_OR_ERROR_AND_EXIT(ret, "IMP_Encoder_CreateChn(" << encChn << ", chnAttr)");
+
 #if defined(PLATFORM_T31) || defined(PLATFORM_C100) || defined(PLATFORM_T40) || defined(PLATFORM_T41)
+    // T41 docs: SetbufshareChn must be called AFTER the shared video channel is created
+    // but BEFORE the JPEG channel is created. This sets up JPEG channel 2 to share
+    // memory with the video channel.
     if (cfg->stream2.enabled && cfg->stream2.jpeg_channel == encChn && stream->allow_shared) {
         ret = IMP_Encoder_SetbufshareChn(2, encChn);
         LOG_DEBUG_OR_ERROR_AND_EXIT(ret, "IMP_Encoder_SetbufshareChn(2, " << encChn << ")");
     }
 #endif
-
-    ret = IMP_Encoder_CreateChn(encChn, &chnAttr);
-    LOG_DEBUG_OR_ERROR_AND_EXIT(ret, "IMP_Encoder_CreateChn(" << encChn << ", chnAttr)");
 
     ret = IMP_Encoder_RegisterChn(encGrp, encChn);
     LOG_DEBUG_OR_ERROR_AND_EXIT(ret, "IMP_Encoder_RegisterChn(" << encGrp << ", " << encChn << ")");
@@ -343,6 +346,12 @@ int IMPEncoder::init()
 
             ret = IMP_System_Bind(&osd_cell, &enc);
             LOG_DEBUG_OR_ERROR_AND_EXIT(ret, "IMP_System_Bind(&osd_cell, &enc)");
+
+            // Initialize detection overlay after OSD binds are complete
+            if (cfg->detection.enabled) {
+                detection = new Detection(encGrp, stream->width, stream->height);
+                detection->init();
+            }
         }
         else
         {
@@ -350,7 +359,8 @@ int IMPEncoder::init()
             LOG_DEBUG_OR_ERROR_AND_EXIT(ret, "IMP_System_Bind(&fs, &enc)");
         }
     }
-#if !(defined(PLATFORM_T31) || !defined(PLATFORM_C100) || !defined(PLATFORM_T40) || !defined(PLATFORM_T41))
+#if !(defined(PLATFORM_T31) || defined(PLATFORM_C100) || defined(PLATFORM_T40) || defined(PLATFORM_T41))
+    // This block is for older platforms (T10/T20/T21/T23/T30) that use IMP_Encoder_SetJpegeQl
     else
     {
         IMPEncoderJpegeQl pstJpegeQl;
@@ -393,6 +403,13 @@ int IMPEncoder::deinit()
             osd->exit();
             delete osd;
             osd = nullptr;
+
+            // Clean up detection overlay
+            if (detection) {
+                detection->exit();
+                delete detection;
+                detection = nullptr;
+            }
         }
         else
         {

--- a/src/IMPEncoder.hpp
+++ b/src/IMPEncoder.hpp
@@ -5,6 +5,7 @@
 #include "Logger.hpp"
 #include "Config.hpp"
 #include "OSD.hpp"
+#include "Detection.hpp"
 #include <imp/imp_encoder.h>
 #include <imp/imp_system.h>
 
@@ -52,6 +53,7 @@ public:
     static void flush(int encChn);
 
     OSD *osd = nullptr;
+    Detection *detection = nullptr;
 
 private:
     IMPEncoderCHNAttr chnAttr{};

--- a/src/OSD.cpp
+++ b/src/OSD.cpp
@@ -1,6 +1,8 @@
 #include <cmath>
 #include "OSD.hpp"
 #include "Config.hpp"
+#include "Detection.hpp"
+#include "IMPEncoder.hpp"
 #include <pthread.h>
 #include "Logger.hpp"
 #include "globals.hpp"
@@ -982,6 +984,11 @@ void *OSD::thread_entry(void *arg) {
                                 v->imp_encoder->osd->start();
                             }
                         }
+                    }
+                    // Update detection overlay if enabled
+                    if (v->imp_encoder->detection != nullptr)
+                    {
+                        v->imp_encoder->detection->update();
                     }
                 }
             }

--- a/src/WS.cpp
+++ b/src/WS.cpp
@@ -1168,6 +1168,14 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
             u_ctx->imaging_dirty = false;
         }
     }
+#else
+    // When NO_TUNINGS is defined, still need to pop the parser on OBJECT_END
+    if (reason == LEJPCB_OBJECT_END)
+    {
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
+        u_ctx->message.append("}");
+        lejp_parser_pop(ctx);
+    }
 #endif
     return 0;
 }


### PR DESCRIPTION

To leverage, add to your `prudynt.json` config:

```"detection": {
    "enabled": true,
    "json_path": "/tmp/detections.json",
    "poll_interval_ms": 200,
    "line_width": 2,
    "box_color": 4278255360,
    "text_color": 4294967295,
    "text_stroke_color": 4278190080,
    "min_confidence": 0.5,
    "show_labels": true,
    "show_confidence": true,
    "max_boxes": 10
},
```

Then separately push the mars binary and runtime libs to /opt and run your favorite mars model in dameon mode:
`LD_LIBRARY_PATH=/opt ./mars_detect -t .5 tinydet_best_float.mars -d`