### PR TITLE
mp4ctl: rewrite recording loop to fix chunk timing inconsistencies

### DIFF
--- a/src/MP4ControlSocket.cpp
+++ b/src/MP4ControlSocket.cpp
@@ -99,32 +99,7 @@ std::array<std::shared_ptr<LoopState>, NUM_VIDEO_CHANNELS> loop_states;
 std::array<std::thread, NUM_VIDEO_CHANNELS> loop_threads;
 std::mutex loop_state_mutex;
 
-std::chrono::system_clock::time_point round_up_to_minute(std::chrono::system_clock::time_point tp) {
-  auto seconds = std::chrono::time_point_cast<std::chrono::seconds>(tp);
-  auto epoch_seconds = seconds.time_since_epoch();
-  auto remainder = epoch_seconds.count() % 60;
-  if (remainder == 0) {
-    return seconds;
-  }
-  return seconds + std::chrono::seconds(60 - remainder);
-}
 
-bool sleep_until_time(std::chrono::system_clock::time_point target, std::atomic<bool> *stop_flag = nullptr) {
-  while (true) {
-    if (stop_flag && stop_flag->load(std::memory_order_relaxed)) {
-      return false;
-    }
-    auto now = std::chrono::system_clock::now();
-    if (now >= target) {
-      return true;
-    }
-    auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(target - now);
-    if (remaining > std::chrono::milliseconds(250)) {
-      remaining = std::chrono::milliseconds(250);
-    }
-    std::this_thread::sleep_for(remaining);
-  }
-}
 
 struct MountEntry {
   fs::path mountPoint;
@@ -860,63 +835,29 @@ void loop_worker(int channel, std::shared_ptr<LoopState> state) {
     return;
   }
 
-  constexpr auto kMinute = std::chrono::seconds(60);
-  constexpr auto kShortClipThreshold = std::chrono::seconds(15);
-
-  bool first_segment_pending = true;
-  auto next_start = std::chrono::system_clock::now();
+  constexpr int kShortClipSeconds = 15;
 
   while (!state->stopRequested.load(std::memory_order_relaxed)) {
-    int segment_duration_seconds = state->params.durationSeconds;
-    std::chrono::system_clock::time_point segment_start;
-
-    if (first_segment_pending) {
-      segment_start = std::chrono::system_clock::now();
-      auto boundary = round_up_to_minute(segment_start);
-      if (boundary <= segment_start) {
-        boundary += kMinute;
-      }
-      auto span = std::chrono::duration_cast<std::chrono::seconds>(boundary - segment_start);
-      if (span < kShortClipThreshold) {
-        boundary += kMinute;
-        span = std::chrono::duration_cast<std::chrono::seconds>(boundary - segment_start);
-      }
-      segment_duration_seconds = static_cast<int>(span.count());
-      if (segment_duration_seconds <= 0) {
-        segment_duration_seconds = state->params.durationSeconds;
-      }
-      next_start = boundary;
-    } else {
-      auto scheduled_start = next_start;
-      auto now = std::chrono::system_clock::now();
-      if (scheduled_start > now) {
-        if (!sleep_until_time(scheduled_start, &state->stopRequested)) {
-          break;
-        }
-      }
-      segment_start = scheduled_start;
-      segment_duration_seconds = state->params.durationSeconds;
-    }
-
     if (!wait_until_channel_idle(channel, &state->stopRequested)) {
       break;
     }
 
-    auto target = build_loop_target_path(state->params, segment_start);
+    int segment_duration_seconds = state->params.durationSeconds;
+    if (segment_duration_seconds < kShortClipSeconds) {
+      segment_duration_seconds = kShortClipSeconds;
+    }
+
+    auto now = std::chrono::system_clock::now();
+    auto target = build_loop_target_path(state->params, now);
     if (target.empty()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(250));
       continue;
     }
+
     if (!begin_segment(target, channel, segment_duration_seconds)) {
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
       continue;
     }
-    if (!first_segment_pending) {
-      // Advance next_start only after segment successfully started
-      next_start = segment_start + std::chrono::seconds(segment_duration_seconds);
-      next_start = round_up_to_minute(next_start);
-    }
-    first_segment_pending = false;
 
     if (!wait_for_recording_completion(channel, &state->stopRequested)) {
       break;


### PR DESCRIPTION
The previous loop_worker implementation attempted to maintain several incorrect timing assumptions and mathematically incompatible invariants simultaneously:
1. Exact video duration (e.g., 60s).
2. Filenames with "round" timestamps (e.g., :00 seconds).
3. Zero processing time between files.
4. Keyframes/metadata arriving exactly at minute boundaries.
5. System clock is monotonic and never jumps (e.g. via NTP).

In practice, this caused issues because:
- Processing overhead (open/close) takes time (1-2s), causing natural drift.
- Wall clock adjustments (NTP) can shift time unexpectedly.
- Keyframes/metadata arrive at unpredictable intervals, often requiring 1-2s delay before creating a new mp4 file.
- The "catch-up" logic intended to align timestamps caused drift, dropped segments, and errors.

This rewrite abandons the attempt to "beautify" timestamps in favor of reliability:
- Independent Iterations: Each recording loop iteration is now independent.
- Natural Drift: We accept that filenames will reflect the actual start time (e.g., 12-34-56.mp4) rather than a forced round number.
- Current Time: Timestamps are derived from now() immediately before file creation, ensuring accuracy over cosmetic alignment.
- Simplified Logic: Removed round_up_to_minute and sleep_until_time helpers.