### PR TITLE
Restore video RTP timestamps for RTSP streams

### DIFF
--- a/src/IMPDeviceSource.cpp
+++ b/src/IMPDeviceSource.cpp
@@ -11,7 +11,12 @@
 static void assignPresentationTime(const AudioFrame &, struct timeval &tv) {
   gettimeofday(&tv, nullptr);
 }
-static void assignPresentationTime(const H264NALUnit &, struct timeval &tv) {
+static void assignPresentationTime(const H264NALUnit &nal, struct timeval &tv) {
+  if (nal.time.tv_sec != 0 || nal.time.tv_usec != 0) {
+    tv = nal.time;
+    return;
+  }
+
   gettimeofday(&tv, nullptr);
 }
 

--- a/src/VideoWorker.cpp
+++ b/src/VideoWorker.cpp
@@ -275,12 +275,10 @@ void VideoWorker::run() {
           continue;
         }
 
-        /* timestamp fix, can be removed if solved
         int64_t nal_ts = stream.pack[stream.packCount - 1].timestamp;
         struct timeval encoder_time;
         encoder_time.tv_sec = nal_ts / 1000000;
         encoder_time.tv_usec = nal_ts % 1000000;
-        */
 
         for (uint32_t i = 0; i < stream.packCount; ++i) {
           bool recorder_active = channel_recorder.isActive();
@@ -439,10 +437,8 @@ void VideoWorker::run() {
           if (global_video[encChn]->hasDataCallback) {
             H264NALUnit nalu;
 
-            /* timestamp fix, can be removed if solved
             nalu.imp_ts = stream.pack[i].timestamp;
             nalu.time = encoder_time;
-            */
 
             // We use start+4 because the encoder inserts 4-byte MPEG
             // 'startcodes' at the beginning of each NAL. Live555 complains.

--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -76,10 +76,8 @@ struct H264NALUnit {
   uint32_t packet_index = 0;        // Position within frame (0-based)
   uint32_t packet_count = 0;        // Total NAL units in frame
 
-  /* timestamp fix, can be removed if solved
-  struct timeval time;
-  int64_t imp_ts;
-  */
+  struct timeval time{0, 0};
+  int64_t imp_ts{0};
 };
 
 struct BackchannelFrame {


### PR DESCRIPTION
## Summary
- restore `H264NALUnit` timestamp fields with defensive zero-init
- propagate encoder timestamps onto outgoing video NAL units in `VideoWorker`
- use propagated video timestamps in `IMPDeviceSource` with fallback to `gettimeofday()` only when no encoder timestamp is available

## Why
Direct RTSP from a Thingino camera on `eufy_t8400x_t31x_sc3338_syn4343` was producing repeated timestamp errors in ffmpeg/Frigate:
- `DTS discontinuity`
- `Application provided invalid, non monotonically increasing dts`

A live binary-only deployment of this patch removed those warnings completely in direct source tests:
- before: 12 warnings in an 8-second direct RTSP probe
- after: 0 warnings in the same 8-second probe
- after: 0 warnings in a longer 20-second probe

## Notes
- audio timestamp behavior is unchanged
- video still falls back to `gettimeofday()` if no propagated timestamp is present, so the change is low risk for streams that do not populate encoder timestamps
