### PR TITLE
Fix RTSP frame timestamps and harden runtime bundle rollout

### DIFF
--- a/scripts/install_camera_bundle.sh
+++ b/scripts/install_camera_bundle.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+	cat <<EOF
+Usage: $(basename "$0") <bundle-dir> <user@host> [password] [remote-dir]
+
+Uploads a prudynt runtime bundle over ssh (no sftp/scp required), installs it
+under the remote directory, repoints /opt/prudynt.patched to the bundle wrapper
+and restarts prudynt.
+EOF
+}
+
+if [[ $# -lt 2 || $# -gt 4 ]]; then
+	usage
+	exit 1
+fi
+
+BUNDLE_DIR="$(readlink -f "$1")"
+REMOTE_HOST="$2"
+REMOTE_PASS="${3:-}"
+REMOTE_DIR="${4:-/opt/prudynt-bundle}"
+
+if [[ ! -f "$BUNDLE_DIR/prudynt" || ! -f "$BUNDLE_DIR/bin/prudynt.real" ]]; then
+	echo "Bundle is incomplete: expected prudynt wrapper and bin/prudynt.real under $BUNDLE_DIR" >&2
+	exit 1
+fi
+
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null)
+if [[ -n "$REMOTE_PASS" ]]; then
+	SSH_BASE=(sshpass -p "$REMOTE_PASS" ssh "${SSH_OPTS[@]}")
+else
+	SSH_BASE=(ssh "${SSH_OPTS[@]}")
+fi
+
+REMOTE_STAGING="${REMOTE_DIR}.staging.$$"
+BACKUP_DIR="/opt/backups/agents/thingino-prudynt-runtime/$(date -u +%F_%H%M%S)"
+
+tar -C "$BUNDLE_DIR" -cf - . | "${SSH_BASE[@]}" "$REMOTE_HOST" "
+set -eu
+rm -rf '$REMOTE_STAGING'
+mkdir -p '$REMOTE_STAGING'
+tar -xf - -C '$REMOTE_STAGING'
+mkdir -p '$BACKUP_DIR'
+if [ -e /opt/prudynt.patched ]; then
+	cp -a /opt/prudynt.patched '$BACKUP_DIR/prudynt.patched.preinstall'
+fi
+if [ -d '$REMOTE_DIR' ]; then
+	mv '$REMOTE_DIR' '$BACKUP_DIR/runtime.previous'
+fi
+
+find_live_pids() {
+	ps w | awk '/\\/opt\\/prudynt-bundle-.*\\/bin\\/prudynt\\.real/ && !/awk/ {print \$1}'
+}
+
+wait_for_live_exit() {
+	retries=\${1:-10}
+	while [ \"\$retries\" -gt 0 ]; do
+		if [ -z \"\$(find_live_pids)\" ]; then
+			return 0
+		fi
+		sleep 1
+		retries=\$((retries - 1))
+	done
+	return 1
+}
+
+current_live_exe() {
+	for pid in \$(find_live_pids); do
+		readlink -f \"/proc/\$pid/exe\" 2>/dev/null || true
+		return 0
+	done
+	return 1
+}
+
+/etc/init.d/S31prudynt stop >/dev/null 2>&1 || true
+if [ -n \"\$(find_live_pids)\" ]; then
+	kill \$(find_live_pids) >/dev/null 2>&1 || true
+fi
+wait_for_live_exit 5 || true
+if [ -n \"\$(find_live_pids)\" ]; then
+	kill -9 \$(find_live_pids) >/dev/null 2>&1 || true
+fi
+wait_for_live_exit 5
+rm -f /run/prudynt.pid
+mv '$REMOTE_STAGING' '$REMOTE_DIR'
+ln -sfn '$REMOTE_DIR/prudynt' /opt/prudynt.patched
+ln -sfn /opt/prudynt.patched /usr/bin/prudynt
+/etc/init.d/S31prudynt start
+sleep 2
+
+EXPECTED_EXE='$REMOTE_DIR/bin/prudynt.real'
+RUNNING_EXE=\$(current_live_exe || true)
+if [ \"\$RUNNING_EXE\" != \"\$EXPECTED_EXE\" ]; then
+	echo \"Expected live prudynt executable \$EXPECTED_EXE but found \${RUNNING_EXE:-none}\" >&2
+	exit 1
+fi
+"
+
+echo "Installed bundle from $BUNDLE_DIR to $REMOTE_HOST:$REMOTE_DIR"

--- a/scripts/package_runtime_bundle.sh
+++ b/scripts/package_runtime_bundle.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+	cat <<EOF
+Usage: $(basename "$0") <binary-path> <output-dir>
+
+Creates a self-contained prudynt runtime bundle with:
+- the target binary under bin/prudynt.real
+- required shared libraries under lib/
+- a wrapper script that sets LD_LIBRARY_PATH relative to itself
+EOF
+}
+
+if [[ $# -ne 2 ]]; then
+	usage
+	exit 1
+fi
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+BINARY_PATH="$(readlink -f "$1")"
+OUTPUT_DIR="$2"
+LIB_DIR="$ROOT_DIR/3rdparty/install/lib"
+
+if [[ ! -f "$BINARY_PATH" ]]; then
+	echo "Binary not found: $BINARY_PATH" >&2
+	exit 1
+fi
+
+if [[ ! -d "$LIB_DIR" ]]; then
+	echo "Library directory not found: $LIB_DIR" >&2
+	exit 1
+fi
+
+declare -A SKIP_NEEDED=(
+	["ld-musl-mipsel.so.1"]=1
+	["libalog.so"]=1
+	["libaudioProcess.so"]=1
+	["libc.so"]=1
+	["libdl.so.0"]=1
+	["libgcc_s.so.1"]=1
+	["libimp.so"]=1
+	["libm.so.6"]=1
+	["libpthread.so.0"]=1
+	["librt.so.1"]=1
+	["libstdc++.so.6"]=1
+	["libsysutils.so"]=1
+)
+
+if [[ -n "${PRUDYNT_BUNDLE_SKIP_LIBS:-}" ]]; then
+	for lib in ${PRUDYNT_BUNDLE_SKIP_LIBS}; do
+		SKIP_NEEDED["$lib"]=1
+	done
+fi
+
+declare -A SONAME_TO_PATH=()
+declare -A REALPATH_TO_DEST=()
+declare -A QUEUED=()
+QUEUE=()
+
+register_library() {
+	local candidate="$1"
+	local real_path
+	real_path="$(readlink -f "$candidate")"
+	[[ -f "$real_path" ]] || return 0
+
+	local base_name
+	base_name="$(basename "$candidate")"
+	SONAME_TO_PATH["$base_name"]="$real_path"
+
+	local real_name
+	real_name="$(basename "$real_path")"
+	SONAME_TO_PATH["$real_name"]="$real_path"
+
+	local soname
+	soname="$(readelf -d "$real_path" 2>/dev/null | awk -F'[][]' '/SONAME/{print $2; exit}')"
+	if [[ -n "$soname" ]]; then
+		SONAME_TO_PATH["$soname"]="$real_path"
+	fi
+}
+
+while IFS= read -r -d '' candidate; do
+	register_library "$candidate"
+done < <(find "$LIB_DIR" -maxdepth 1 \( -type f -o -type l \) -name 'lib*.so*' -print0)
+
+enqueue_needed() {
+	local object_path="$1"
+	local dependency
+	while IFS= read -r dependency; do
+		[[ -n "$dependency" ]] || continue
+		[[ -n "${SKIP_NEEDED[$dependency]:-}" ]] && continue
+		if [[ -z "${QUEUED[$dependency]:-}" ]]; then
+			QUEUED["$dependency"]=1
+			QUEUE+=("$dependency")
+		fi
+	done < <(readelf -d "$object_path" 2>/dev/null | awk -F'[][]' '/NEEDED/{print $2}')
+}
+
+mkdir -p "$OUTPUT_DIR/bin" "$OUTPUT_DIR/lib"
+cp -f "$BINARY_PATH" "$OUTPUT_DIR/bin/prudynt.real"
+
+enqueue_needed "$BINARY_PATH"
+
+copy_library() {
+	local needed="$1"
+	local source_path="${SONAME_TO_PATH[$needed]:-}"
+	if [[ -z "$source_path" ]]; then
+		echo "Unable to resolve shared library: $needed" >&2
+		exit 1
+	fi
+
+	local source_real
+	source_real="$(readlink -f "$source_path")"
+	local source_base
+	source_base="$(basename "$source_real")"
+	local dest_real="$OUTPUT_DIR/lib/$source_base"
+
+	if [[ -z "${REALPATH_TO_DEST[$source_real]:-}" ]]; then
+		rm -f "$dest_real"
+		install -m 0644 "$source_real" "$dest_real"
+		REALPATH_TO_DEST["$source_real"]="$dest_real"
+
+		local file_name
+		file_name="$(basename "$source_path")"
+		if [[ "$file_name" != "$source_base" ]]; then
+			ln -sfn "$source_base" "$OUTPUT_DIR/lib/$file_name"
+		fi
+
+		local soname
+		soname="$(readelf -d "$source_real" 2>/dev/null | awk -F'[][]' '/SONAME/{print $2; exit}')"
+		if [[ -n "$soname" && "$soname" != "$source_base" ]]; then
+			ln -sfn "$source_base" "$OUTPUT_DIR/lib/$soname"
+		fi
+
+		enqueue_needed "$source_real"
+	fi
+
+	if [[ "$needed" != "$source_base" ]]; then
+		ln -sfn "$source_base" "$OUTPUT_DIR/lib/$needed"
+	fi
+}
+
+while [[ ${#QUEUE[@]} -gt 0 ]]; do
+	needed="${QUEUE[0]}"
+	QUEUE=("${QUEUE[@]:1}")
+	copy_library "$needed"
+done
+
+cat > "$OUTPUT_DIR/prudynt" <<'EOF'
+#!/bin/sh
+set -eu
+
+resolve_self() {
+	target="$1"
+	while [ -L "$target" ]; do
+		dir=$(dirname "$target")
+		link=$(readlink "$target")
+		case "$link" in
+			/*) target="$link" ;;
+			*) target="$dir/$link" ;;
+		esac
+	done
+	printf '%s\n' "$target"
+}
+
+SELF=$(resolve_self "$0")
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$SELF")" && pwd)
+export LD_LIBRARY_PATH="$ROOT_DIR/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+if [ -f "$ROOT_DIR/lib/libmuslshim.so" ]; then
+	export LD_PRELOAD="$ROOT_DIR/lib/libmuslshim.so${LD_PRELOAD:+ $LD_PRELOAD}"
+fi
+exec "$ROOT_DIR/bin/prudynt.real" "$@"
+EOF
+chmod 755 "$OUTPUT_DIR/prudynt"
+
+# Thingino cameras on musl often expose only /lib/libc.so while vendor libs
+# still declare glibc-style SONAMEs such as libc.so.0 and libpthread.so.0.
+# Provide compatibility symlinks inside the bundle so bundled live555/json/etc.
+# can coexist with platform IMP libs without touching system libraries.
+ln -sfn /lib/libc.so "$OUTPUT_DIR/lib/libc.so.0"
+ln -sfn /lib/libc.so "$OUTPUT_DIR/lib/libpthread.so.0"
+ln -sfn /lib/libc.so "$OUTPUT_DIR/lib/libdl.so.0"
+ln -sfn /lib/libc.so "$OUTPUT_DIR/lib/libm.so.0"
+ln -sfn /lib/libc.so "$OUTPUT_DIR/lib/librt.so.1"
+
+{
+	echo "binary=$(basename "$BINARY_PATH")"
+	echo "created_at=$(date -u +%FT%TZ)"
+	find "$OUTPUT_DIR/lib" -maxdepth 1 \( -type f -o -type l \) | sort | sed "s#^$OUTPUT_DIR/##"
+} > "$OUTPUT_DIR/MANIFEST.txt"
+
+echo "Runtime bundle created at $OUTPUT_DIR"

--- a/src/VideoWorker.cpp
+++ b/src/VideoWorker.cpp
@@ -49,19 +49,31 @@ void VideoWorker::run() {
           continue;
         }
 
-        // SINGLE SOURCE OF TRUTH: Use TimestampManager (which uses IMP hardware
-        // timestamps)
-        struct timeval monotonic_time;
-        TimestampManager::getInstance().getTimestamp(&monotonic_time);
-
-        // TIMESTAMP DEBUG: Log video frame processing (use first pack
-        // timestamp)
-        int64_t pack_timestamp =
+        // Use the encoder-provided frame timestamp as the presentation time
+        // for every NAL that belongs to this encoded frame. This keeps video
+        // timestamps aligned to the hardware encoder timeline instead of the
+        // wall-clock moment when we happened to poll the frame.
+        int64_t frame_timestamp =
             (stream.packCount > 0) ? stream.pack[0].timestamp : -1;
-        LOG_DEBUG("VIDEO_TIMESTAMP_1_PROCESS: pack_timestamp="
-                  << pack_timestamp
-                  << " monotonic_time.tv_sec=" << monotonic_time.tv_sec
-                  << " monotonic_time.tv_usec=" << monotonic_time.tv_usec);
+        if (frame_timestamp < 0) {
+          frame_timestamp = TimestampManager::getInstance().getTimestampUs();
+        }
+
+        struct timeval frame_time;
+        frame_time.tv_sec = frame_timestamp / 1000000;
+        frame_time.tv_usec = frame_timestamp % 1000000;
+
+        unsigned frame_duration_us = 0;
+        if (global_video[encChn]->stream->fps > 0) {
+          frame_duration_us =
+              1000000 / static_cast<unsigned>(global_video[encChn]->stream->fps);
+        }
+
+        LOG_DEBUG("VIDEO_TIMESTAMP_1_PROCESS: frame_timestamp="
+                  << frame_timestamp << " frame_time.tv_sec="
+                  << frame_time.tv_sec << " frame_time.tv_usec="
+                  << frame_time.tv_usec << " duration_us="
+                  << frame_duration_us);
 
         for (uint32_t i = 0; i < stream.packCount; ++i) {
           fps++;
@@ -80,7 +92,9 @@ void VideoWorker::run() {
 #endif
 
             H264NALUnit nalu;
-            nalu.time = monotonic_time;
+            nalu.time = frame_time;
+            nalu.durationInMicroseconds = frame_duration_us;
+            nalu.endsAccessUnit = stream.pack[i].frameEnd;
 
             // We use start+4 because the encoder inserts 4-byte MPEG
             //'startcodes' at the beginning of each NAL. Live555 complains


### PR DESCRIPTION
## Summary
- use the encoder-provided frame timestamp for emitted H264 NAL units
- derive per-frame duration from the configured FPS when emitting video frames
- add runtime bundle packaging/install helpers and validate that the new prudynt bundle is actually live after restart

## Validation
- validated on a Thingino T31 camera streaming `2304x1296@30fps`
- direct RTSP probe no longer showed non-monotonic DTS warnings in the validation window
- go2rtc / Frigate ingest stabilized after switching the camera to the patched runtime bundle

## Notes
- the runtime install helper explicitly handles the case where the init script stops the wrapper but misses the already-exec'd `prudynt.real` process
- keeping this as draft until maintainer review decides whether the helper scripts belong upstream as-is
