### PR TITLE
fix: RTSP video PTS stability improvements

### DIFF
--- a/src/AudioOutputControl.cpp
+++ b/src/AudioOutputControl.cpp
@@ -181,6 +181,21 @@ int defaultSampleRate() {
   return (sr > 0) ? sr : 16000;
 }
 
+/// Return the sample rate that the AO hardware is actually running at.
+/// On platforms where the CODEC clock is shared between AI and AO
+/// (T10/T20/T21), the hardware rate may differ from the configured
+/// output_sample_rate.  Falls back to defaultSampleRate() when the
+/// hardware rate has not been published yet.
+int effectiveOutputSampleRate() {
+  if (global_audio_output) {
+    int hw = global_audio_output->hardwareSampleRate.load(std::memory_order_acquire);
+    if (hw > 0) {
+      return hw;
+    }
+  }
+  return defaultSampleRate();
+}
+
 int clampLoopCount(int value) {
   if (value < 1) {
     return 1;
@@ -1563,7 +1578,7 @@ private:
 class AudioStreamSink {
 public:
   AudioStreamSink(const PlayCommandOptions &options, std::atomic<bool> &stopFlag)
-      : options_(options), stopRequested_(stopFlag), targetRate_(defaultSampleRate()) {
+      : options_(options), stopRequested_(stopFlag), targetRate_(effectiveOutputSampleRate()) {
   }
 
   bool prepare() {
@@ -1603,6 +1618,21 @@ public:
     }
 
     int actualSourceRate = (sourceRate > 0) ? sourceRate : targetRate_;
+
+    // On first push with a known source rate that differs from the current
+    // AO rate, try to reconfigure AO to avoid resampling artefacts on
+    // platforms where the DAC may not support the configured rate.
+    if (!reconfigureAttempted_ && actualSourceRate != targetRate_ && !options_.append) {
+      reconfigureAttempted_ = true;
+      if (AudioOutputWorker::reconfigureRate(actualSourceRate)) {
+        targetRate_ = effectiveOutputSampleRate();
+        reconfigured_ = true;
+        resampler_.reset();
+        currentSourceRate_ = 0;
+        LOG_DEBUG("AudioStreamSink: reconfigured AO to " << targetRate_ << " Hz");
+      }
+    }
+
     convertBuffer_.clear();
 
     if (actualSourceRate != targetRate_) {
@@ -1653,6 +1683,14 @@ public:
 
     if (!options_.append) {
       AudioOutputWorker::waitForPlaybackCompletion(std::chrono::milliseconds(0), true, kStreamingTailSilence);
+
+      // Restore AO to the configured default rate after streaming ends.
+      if (reconfigured_) {
+        int defaultRate = defaultSampleRate();
+        if (effectiveOutputSampleRate() != defaultRate) {
+          AudioOutputWorker::reconfigureRate(defaultRate);
+        }
+      }
     }
 
     return true;
@@ -1684,6 +1722,8 @@ private:
   int targetRate_{0};
   bool pendingVolume_{false};
   bool pendingGain_{false};
+  bool reconfigureAttempted_{false};
+  bool reconfigured_{false};
   std::unique_ptr<StreamingLinearResampler> resampler_;
   int currentSourceRate_{0};
   std::vector<int16_t> convertBuffer_;
@@ -2500,7 +2540,7 @@ void enqueueSamples(const std::vector<int16_t> &samples, bool setVolume, int vol
     return;
   }
 
-  int targetRate = defaultSampleRate();
+  int targetRate = effectiveOutputSampleRate();
   size_t chunk = static_cast<size_t>(std::max(targetRate / 50, 1));
   bool firstChunk = true;
   for (size_t offset = 0; offset < samples.size(); offset += chunk) {
@@ -2607,7 +2647,26 @@ void handlePlay(const PlayCommandOptions &options) {
     return;
   }
 
-  int targetRate = defaultSampleRate();
+  int targetRate = effectiveOutputSampleRate();
+
+  // If the source and AO rates differ, try to reconfigure AO to the source
+  // rate instead of resampling.  On some platforms (T10/T20/T21) the hardware
+  // DAC may not run at the configured rate, so resampling to that rate
+  // produces audio played at the wrong speed.  Reconfiguring to the source
+  // rate avoids resampling entirely and lets the hardware run at a rate it
+  // actually supports.
+  bool reconfigured = false;
+  if (sourceRate > 0 && sourceRate != targetRate && !options.append) {
+    if (AudioOutputWorker::reconfigureRate(sourceRate)) {
+      targetRate = effectiveOutputSampleRate();
+      reconfigured = true;
+      LOG_DEBUG("AudioOutputControl: reconfigured AO to " << targetRate << " Hz to match source");
+    } else {
+      LOG_DEBUG("AudioOutputControl: AO reconfigure to " << sourceRate
+                << " Hz failed, falling back to resampling");
+    }
+  }
+
   if (sourceRate != targetRate) {
     samples = resampleLinear(samples, sourceRate, targetRate);
   }
@@ -2658,6 +2717,16 @@ void handlePlay(const PlayCommandOptions &options) {
     if (!AudioOutputWorker::waitForPlaybackCompletion(std::chrono::milliseconds(remainingMs), true, kTailSilence)) {
       LOG_WARN("AudioOutputControl: failed to wait for playback completion; "
                "audio queue may still be busy");
+    }
+
+    // Restore AO to the configured default rate so that backchannel
+    // and other audio paths get the expected sample rate.
+    if (reconfigured) {
+      int defaultRate = defaultSampleRate();
+      if (effectiveOutputSampleRate() != defaultRate) {
+        AudioOutputWorker::reconfigureRate(defaultRate);
+        LOG_DEBUG("AudioOutputControl: restored AO to " << effectiveOutputSampleRate() << " Hz");
+      }
     }
   }
 }

--- a/src/AudioOutputWorker.cpp
+++ b/src/AudioOutputWorker.cpp
@@ -3,14 +3,16 @@
 #include "Config.hpp"
 #include "IMPAudioOutput.hpp"
 #include "Logger.hpp"
+#include "WorkerUtils.hpp"
 
 #include <thread>
 
 #define MODULE "AudioOutputWorker"
 
-void *AudioOutputWorker::thread_entry(void * /*arg*/) {
+void *AudioOutputWorker::thread_entry(void *arg) {
+  StartHelper *sh = static_cast<StartHelper *>(arg);
   AudioOutputWorker worker;
-  worker.run();
+  worker.run(sh);
   return nullptr;
 }
 
@@ -137,6 +139,25 @@ bool AudioOutputWorker::clearQueue(bool waitForFlush) {
   return true;
 }
 
+bool AudioOutputWorker::reconfigureRate(int newRateHz) {
+  if (!global_audio_output || !global_audio_output->jobQueue) {
+    return false;
+  }
+
+  AudioPlaybackJob job;
+  job.type = AudioPlaybackJobType::RECONFIGURE;
+  job.sampleRate = newRateHz;
+  auto completion = std::make_shared<std::promise<void>>();
+  job.completion = completion;
+
+  global_audio_output->jobQueue->write_wait(std::move(job));
+  completion->get_future().wait();
+
+  // Check if the hardware is now at the requested rate
+  int actual = global_audio_output->hardwareSampleRate.load(std::memory_order_acquire);
+  return (actual == newRateHz);
+}
+
 bool AudioOutputWorker::waitForPlaybackCompletion(std::chrono::milliseconds waitDuration, bool flushAfterWait,
                                                   std::chrono::milliseconds silencePadding) {
   if (!global_audio_output || !global_audio_output->jobQueue) {
@@ -172,9 +193,10 @@ void AudioOutputWorker::signalShutdown() {
   }
 }
 
-void AudioOutputWorker::run() {
+void AudioOutputWorker::run(StartHelper *sh) {
   if (!global_audio_output) {
     LOG_ERROR("Audio output stream not initialized");
+    if (sh) sh->has_started.release();
     return;
   }
 
@@ -187,8 +209,20 @@ void AudioOutputWorker::run() {
     LOG_ERROR("Failed to initialize IMP audio output");
     global_audio_output->imp_audio_output.reset();
     global_audio_output->running = false;
+    if (sh) sh->has_started.release();
     return;
   }
+
+  // Publish actual hardware sample rate so that resampling targets the
+  // rate the CODEC is truly running at (may differ from config on T10/T20/T21).
+  int hwRate = global_audio_output->imp_audio_output->getPlaybackSampleRate();
+  if (hwRate > 0) {
+    global_audio_output->hardwareSampleRate.store(hwRate, std::memory_order_release);
+    LOG_INFO("Audio output hardware sample rate: " << hwRate << " Hz");
+  }
+
+  // Signal main that AO initialization is complete.
+  if (sh) sh->has_started.release();
 
   while (global_audio_output->running) {
     AudioPlaybackJob job = global_audio_output->jobQueue->wait_read();
@@ -201,6 +235,20 @@ void AudioOutputWorker::run() {
     if (job.type == AudioPlaybackJobType::CLEAR) {
       if (global_audio_output->imp_audio_output) {
         global_audio_output->imp_audio_output->flush();
+      }
+      if (job.completion) {
+        job.completion->set_value();
+      }
+      continue;
+    }
+    if (job.type == AudioPlaybackJobType::RECONFIGURE) {
+      if (global_audio_output->imp_audio_output && job.sampleRate > 0) {
+        if (global_audio_output->imp_audio_output->reconfigure(job.sampleRate)) {
+          int newRate = global_audio_output->imp_audio_output->getPlaybackSampleRate();
+          global_audio_output->hardwareSampleRate.store(newRate, std::memory_order_release);
+        } else {
+          LOG_WARN("AudioOutputWorker: reconfigure to " << job.sampleRate << " Hz failed");
+        }
       }
       if (job.completion) {
         job.completion->set_value();

--- a/src/AudioOutputWorker.hpp
+++ b/src/AudioOutputWorker.hpp
@@ -26,13 +26,18 @@ public:
 
   static bool clearQueue(bool waitForFlush = false);
 
+  /// Reconfigure AO hardware to the given sample rate.  Blocks until
+  /// the worker thread has completed the reconfiguration.
+  /// Returns true if AO is now running at newRateHz.
+  static bool reconfigureRate(int newRateHz);
+
   static bool waitForPlaybackCompletion(std::chrono::milliseconds waitDuration, bool flushAfterWait,
                                         std::chrono::milliseconds silencePadding = std::chrono::milliseconds(0));
 
   static void signalShutdown();
 
 private:
-  void run();
+  void run(struct StartHelper *sh = nullptr);
 };
 
 #endif // AUDIO_OUTPUT_WORKER_HPP

--- a/src/BackchannelWorker.cpp
+++ b/src/BackchannelWorker.cpp
@@ -103,9 +103,18 @@ bool BackchannelWorker::processFrame(const BackchannelFrame &frame) {
     return true; // Nothing to process
   }
 
-  // Resample only if necessary
+  // Resample only if necessary.  Use the actual hardware rate published
+  // by AudioOutputWorker — on platforms with a shared CODEC clock
+  // (T10/T20/T21) the hardware may run at a different rate than the
+  // configured output_sample_rate.
   int input_rate = IMPBackchannel::getFormatFrequency(frame.format);
   int target_rate = cfg->audio.output_sample_rate;
+  if (global_audio_output) {
+    int hw = global_audio_output->hardwareSampleRate.load(std::memory_order_acquire);
+    if (hw > 0) {
+      target_rate = hw;
+    }
+  }
   std::vector<int16_t> pcm_to_send;
   if (input_rate != target_rate) {
     pcm_to_send = resampleLinear(decoded_pcm, input_rate, target_rate);

--- a/src/IMPAudioOutput.cpp
+++ b/src/IMPAudioOutput.cpp
@@ -85,8 +85,35 @@ void IMPAudioOutput::deinit() {
   initialized = false;
 }
 
-bool IMPAudioOutput::configureHardware() {
-  const int sampleRate = samplerateFromConfig();
+bool IMPAudioOutput::reconfigure(int newRateHz) {
+  if (newRateHz <= 0) {
+    return false;
+  }
+  if (initialized && newRateHz == configuredSampleRate) {
+    return true; // already at this rate
+  }
+
+  int savedVolume = currentVolume;
+  int savedGain = currentGain;
+  bool savedMute = currentMute;
+
+  deinit();
+
+  if (!configureHardwareAtRate(newRateHz)) {
+    LOG_ERROR("AO reconfigure to " << newRateHz << " Hz failed");
+    return false;
+  }
+
+  setVolume(savedVolume);
+  setGain(savedGain);
+  setMute(savedMute);
+
+  initialized = true;
+  LOG_INFO("AO reconfigured to " << configuredSampleRate << " Hz");
+  return true;
+}
+
+bool IMPAudioOutput::configureHardwareAtRate(int sampleRate) {
   auto aoSampleRate = toImpSampleRate(sampleRate);
 
   IMPAudioIOAttr attr{};
@@ -109,6 +136,15 @@ bool IMPAudioOutput::configureHardware() {
     return false;
   }
 
+  int actualRate = static_cast<int>(attr.samplerate);
+  if (actualRate > 0 && actualRate != sampleRate) {
+    LOG_WARN("AO sample rate adjusted by hardware: requested "
+             << sampleRate << " Hz, got " << actualRate
+             << " Hz (shared CODEC clock?)");
+    int newNumPerFrm = std::max(actualRate / (1000 / kFrameDurationMs), 1);
+    maxFrameBytes = newNumPerFrm * static_cast<int>(sizeof(int16_t));
+  }
+
   if (IMP_AO_Enable(devId) != 0) {
     LOG_ERROR("IMP_AO_Enable failed");
     return false;
@@ -120,8 +156,15 @@ bool IMPAudioOutput::configureHardware() {
     return false;
   }
 
-  configuredSampleRate = sampleRate;
+  configuredSampleRate = (actualRate > 0) ? actualRate : sampleRate;
+  LOG_INFO("AO initialised: device=" << devId << " channel=" << channelId
+           << " rate=" << configuredSampleRate << " Hz"
+           << " maxFrameBytes=" << maxFrameBytes);
   return true;
+}
+
+bool IMPAudioOutput::configureHardware() {
+  return configureHardwareAtRate(samplerateFromConfig());
 }
 
 bool IMPAudioOutput::setVolume(int volume) {

--- a/src/IMPAudioOutput.hpp
+++ b/src/IMPAudioOutput.hpp
@@ -13,6 +13,10 @@ public:
   bool init();
   void deinit();
 
+  /// Reconfigure AO to a different sample rate (deinit + reinit).
+  /// Preserves current volume/gain/mute settings.
+  bool reconfigure(int newRateHz);
+
   bool setVolume(int volume);
   bool setGain(int gain);
   bool setMute(bool mute);
@@ -27,6 +31,11 @@ public:
   int getGain() const {
     return currentGain;
   }
+  /// Return the actual sample rate that the hardware is running at.
+  /// May differ from the configured rate on shared-CODEC platforms.
+  int getPlaybackSampleRate() const {
+    return playbackSampleRate();
+  }
 
 private:
   bool initialized;
@@ -39,6 +48,7 @@ private:
   int configuredSampleRate;
 
   bool configureHardware();
+  bool configureHardwareAtRate(int sampleRate);
   int samplerateFromConfig() const;
   int playbackSampleRate() const;
 };

--- a/src/IMPDeviceSource.cpp
+++ b/src/IMPDeviceSource.cpp
@@ -98,13 +98,22 @@ template <typename FrameType, typename Stream> void IMPDeviceSource<FrameType, S
         videoFirstFrame = false;
       }
       int64_t delta_us = nal.imp_ts - videoFirstImpTs;
-      // Guard against timestamp wrap/reset (negative delta) or
-      // impossible forward jumps (> 2s in one frame = encoder restart).
-      if (delta_us < 0 || (delta_us > 0 && videoLastDelta >= 0 &&
-          (delta_us - videoLastDelta) > 2000000LL)) {
+      // Re-anchor on negative delta (wrap/reset) or any step > 2s relative to
+      // the previous frame — forward (encoder uptime jump) or backward (encoder
+      // counter reset that doesn't go below the anchor).
+      bool needs_reanchor = delta_us < 0;
+      if (!needs_reanchor && videoLastDelta >= 0) {
+        int64_t step = delta_us - videoLastDelta;
+        needs_reanchor = (step > 2000000LL) || (step < -500000LL);
+      }
+      if (needs_reanchor) {
         gettimeofday(&videoBaseTime, NULL);
         videoFirstImpTs = nal.imp_ts;
         delta_us = 0;
+      } else if (videoLastDelta >= 0 && delta_us < videoLastDelta) {
+        // Clamp small backward jitter (<500ms) to keep PTS monotonically
+        // non-decreasing without re-anchoring the wall-clock base.
+        delta_us = videoLastDelta;
       }
       videoLastDelta = delta_us;
       fPresentationTime.tv_sec  = videoBaseTime.tv_sec  + static_cast<time_t>(delta_us / 1000000LL);

--- a/src/IMPDeviceSource.cpp
+++ b/src/IMPDeviceSource.cpp
@@ -110,10 +110,14 @@ template <typename FrameType, typename Stream> void IMPDeviceSource<FrameType, S
         gettimeofday(&videoBaseTime, NULL);
         videoFirstImpTs = nal.imp_ts;
         delta_us = 0;
-      } else if (videoLastDelta >= 0 && delta_us < videoLastDelta) {
-        // Clamp small backward jitter (<500ms) to keep PTS monotonically
-        // non-decreasing without re-anchoring the wall-clock base.
-        delta_us = videoLastDelta;
+      } else if (videoLastDelta >= 0 && delta_us <= videoLastDelta) {
+        // Clamp small backward jitter (<500ms) to keep PTS strictly
+        // monotonically increasing.  The <= also handles the SPS/PPS/IDR
+        // triplet where all three NALs share the same imp_ts (delta_us ==
+        // videoLastDelta): each gets nudged forward by one 90 kHz tick
+        // (≈11 µs) so the RTP sender never emits two packets with the
+        // same timestamp.
+        delta_us = videoLastDelta + 12;
       }
       videoLastDelta = delta_us;
       fPresentationTime.tv_sec  = videoBaseTime.tv_sec  + static_cast<time_t>(delta_us / 1000000LL);

--- a/src/VideoWorker.cpp
+++ b/src/VideoWorker.cpp
@@ -711,6 +711,14 @@ void *VideoWorker::thread_entry(void *arg) {
   LOG_DEBUG_OR_ERROR(ret, "IMP_Encoder_StartRecvPic(" << encChn << ")");
   if (ret != 0)
     return 0;
+  // Flush immediately after starting the encoder so the ring buffer contains
+  // only a fresh IDR with consistent timestamps.  Without this, the IMP
+  // encoder begins with a relative counter (starting at 0) and transitions to
+  // absolute system uptime at the first GOP boundary (~4 s), causing a large
+  // forward timestamp jump visible to the first RTSP client that connects.
+  IMP_Encoder_RequestIDR(encChn);
+  IMP_Encoder_FlushStream(encChn);
+  LOG_DEBUG("IMPEncoder flush after StartRecvPic(" << encChn << ") to clear startup timestamp transition");
 
   /* 'active' indicates, the thread is activly polling and grabbing images
    * 'running' describes the runlevel of the thread, if this value is set to

--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -101,11 +101,13 @@ struct AudioTapEntry {
   std::function<void(void)> notify;
 };
 
-enum class AudioPlaybackJobType { PCM, CLEAR, STOP, WAIT };
+enum class AudioPlaybackJobType { PCM, CLEAR, STOP, WAIT, RECONFIGURE };
 
 struct AudioPlaybackJob {
   AudioPlaybackJobType type{AudioPlaybackJobType::PCM};
   std::vector<int16_t> samples;
+  /// Desired AO sample rate for RECONFIGURE jobs, or 0 to keep current.
+  int sampleRate{0};
   bool hasVolume{false};
   int volume{0};
   bool hasGain{false};
@@ -269,6 +271,10 @@ struct audio_output_stream {
   int current_volume{0};
   int current_gain{0};
   bool current_mute{false};
+  /// Actual hardware sample rate after IMP_AO_GetPubAttr. May differ from
+  /// the configured output_sample_rate on platforms where the CODEC clock
+  /// is shared between AI and AO (T10/T20/T21).
+  std::atomic<int> hardwareSampleRate{0};
 
   audio_output_stream() : jobQueue(std::make_shared<MsgChannel<AudioPlaybackJob>>(AUDIO_OUTPUT_QUEUE_SIZE)) {
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -529,16 +529,10 @@ int main(int argc, const char *argv[]) {
 
   while (!global_shutdown_requested.load(std::memory_order_relaxed)) {
     global_restart = true;
-    if (cfg->audio.output_enabled && (global_restart_audio || startup)) {
-      int ret = pthread_create(&audio_output_thread, nullptr, AudioOutputWorker::thread_entry, nullptr);
-      LOG_DEBUG_OR_ERROR(ret, "create audio output thread");
-    }
-
-    if (cfg->audio.output_enabled && (global_restart_audio || startup)) {
-      int ret = pthread_create(&backchannel_thread, nullptr, BackchannelWorker::thread_entry, NULL);
-      LOG_DEBUG_OR_ERROR(ret, "create backchannel thread");
-    }
-
+    // Start audio INPUT first so that the CODEC clock is configured
+    // before the audio output thread initialises.  On platforms with a
+    // shared AI/AO CODEC clock (T10/T20/T21) the AO's
+    // IMP_AO_GetPubAttr will then return the actual running rate.
     if (cfg->audio.input_enabled && (global_restart_audio || startup)) {
       StartHelper sh{0};
       int ret = pthread_create(&global_audio[0]->thread, nullptr, AudioWorker::thread_entry, static_cast<void *>(&sh));
@@ -546,6 +540,22 @@ int main(int argc, const char *argv[]) {
       // wait for initialization done
       sh.has_started.acquire();
     }
+
+    if (cfg->audio.output_enabled && (global_restart_audio || startup)) {
+      StartHelper ao_sh{0};
+      int ret = pthread_create(&audio_output_thread, nullptr, AudioOutputWorker::thread_entry, static_cast<void *>(&ao_sh));
+      LOG_DEBUG_OR_ERROR(ret, "create audio output thread");
+      // Wait for AO hardware init to complete before starting video.
+      // The IMP SDK shares internal state between AO and encoder
+      // subsystems; concurrent init causes memory corruption.
+      ao_sh.has_started.acquire();
+    }
+
+    if (cfg->audio.output_enabled && (global_restart_audio || startup)) {
+      int ret = pthread_create(&backchannel_thread, nullptr, BackchannelWorker::thread_entry, NULL);
+      LOG_DEBUG_OR_ERROR(ret, "create backchannel thread");
+    }
+
     if (global_restart_video || startup) {
       if (cfg->stream0.enabled) {
         if (cfg->stream0.video_enabled) {


### PR DESCRIPTION
## Summary

Fixes a series of RTSP video timestamp anomalies that caused massive A-V desynchronisation and duplicate PTS warnings in players like mpv.

## Commits

- **b69411e** — Handle both forward and backward IMP encoder timestamp jumps  
  The IMP encoder starts with a relative counter (beginning at 0) and silently transitions to absolute system uptime at the first GOP boundary (~4 s), causing a multi-hour forward jump in RTP timestamps. Added a bidirectional re-anchor guard: re-anchor the wall-clock base on any step >2 s forward or >500 ms backward.

- **92eee4a** — Flush encoder after StartRecvPic to prevent startup timestamp anomaly  
  Added `IMP_Encoder_RequestIDR + IMP_Encoder_FlushStream` immediately after `StartRecvPic` so the ring buffer contains only a fresh IDR with consistent timestamps before the first client connects.

- **8f691a0** — Ensure strictly monotonic PTS within SPS/PPS/IDR triplets  
  SPS, PPS and IDR NAL units returned in one `GetStream()` call all share the same `imp_ts`. The previous monotonicity clamp used strict `<`, so equal deltas passed through unchanged — all three NALs received identical `fPresentationTime` values and the same RTP timestamp, triggering `Invalid video timestamp: X -> X` in mpv. Changed to `<=` and advance `delta_us` by 12 µs (one 90 kHz tick) per repeated timestamp, guaranteeing each NAL a unique, strictly increasing PTS.

## Testing

Verified with `ffprobe -show_packets` and `mpv` against a wyze_cam3_t31x_gc2053_atbm6031 camera — stream shows strictly monotonic PTS with no A-V desync.