### PR TITLE
fix: harden RTSP timestamp handling

### DIFF
--- a/src/AudioReframer.cpp
+++ b/src/AudioReframer.cpp
@@ -5,7 +5,7 @@
 AudioReframer::AudioReframer(unsigned int inputSampleRate, unsigned int inputSamplesPerFrame,
                              unsigned int outputSamplesPerFrame)
     : inputSampleRate(inputSampleRate), inputSamplesPerFrame(inputSamplesPerFrame),
-      outputSamplesPerFrame(outputSamplesPerFrame), currentTimestamp(0), samplesAccumulated(0),
+      outputSamplesPerFrame(outputSamplesPerFrame), currentTimestamp(0), timestampRemainder(0), samplesAccumulated(0),
       buffer(2 * std::max(inputSamplesPerFrame, outputSamplesPerFrame) * sizeof(uint16_t)) {
   if (inputSamplesPerFrame == 0 || outputSamplesPerFrame == 0) {
     throw std::invalid_argument("Number of samples per frame must be greater than zero.");
@@ -22,6 +22,7 @@ void AudioReframer::addFrame(const uint8_t *frameData, int64_t timestamp) {
 
   if (samplesAccumulated == 0) {
     currentTimestamp = timestamp; // Initialize timestamp with the first frame
+    timestampRemainder = 0;
   }
 
   samplesAccumulated += inputSamplesPerFrame;
@@ -42,7 +43,14 @@ void AudioReframer::getReframedFrame(uint8_t *frameData, int64_t &timestamp) {
 
   timestamp = currentTimestamp;
   if (inputSampleRate > 0) {
-    currentTimestamp += (outputSamplesPerFrame * 1000) / inputSampleRate;
+    // Timestamp is in microseconds; preserve fractional precision between frames.
+    int64_t numer = static_cast<int64_t>(outputSamplesPerFrame) * 1000000LL + timestampRemainder;
+    int64_t step_us = numer / static_cast<int64_t>(inputSampleRate);
+    timestampRemainder = numer % static_cast<int64_t>(inputSampleRate);
+    if (step_us < 1) {
+      step_us = 1;
+    }
+    currentTimestamp += step_us;
   } // else: keep currentTimestamp stable if misconfigured
 }
 

--- a/src/AudioReframer.hpp
+++ b/src/AudioReframer.hpp
@@ -20,6 +20,7 @@ private:
   unsigned int inputSamplesPerFrame;
   unsigned int outputSamplesPerFrame;
   int64_t currentTimestamp;
+  int64_t timestampRemainder;
   size_t samplesAccumulated;
 
   RingBuffer buffer;

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -470,8 +470,8 @@ std::vector<ConfigItem<int>> CFG::getIntItems() {
       {"audio.spk_gain", audio.output_gain, 20, [](const int &v) { return v >= 0 && v <= 31; }},
       {"audio.spk_vol", audio.output_vol, 60, [](const int &v) { return v >= -30 && v <= 120; }},
 #endif
-      {"audio.buffer_warn_frames", audio.buffer_warn_frames, 80, [](const int &v) { return v >= 10 && v <= 1000; }},
-      {"audio.buffer_cap_frames", audio.buffer_cap_frames, 100, [](const int &v) { return v >= 10 && v <= 1000; }},
+      {"audio.buffer_warn_frames", audio.buffer_warn_frames, 240, [](const int &v) { return v >= 10 && v <= 1000; }},
+      {"audio.buffer_cap_frames", audio.buffer_cap_frames, 400, [](const int &v) { return v >= 10 && v <= 1000; }},
       {"daynight.switch_below_percent", daynight.switch_below_percent, 15, [](const int &v) { return v >= 0 && v <= 100; }},
       {"daynight.switch_above_percent", daynight.switch_above_percent, 80, [](const int &v) { return v >= 0 && v <= 100; }},
       {"daynight.tolerance_percent", daynight.tolerance_percent, 50, [](const int &v) { return v >= 0 && v <= 100; }},

--- a/src/IMPAudioServerMediaSubsession.cpp
+++ b/src/IMPAudioServerMediaSubsession.cpp
@@ -29,6 +29,9 @@ FramedSource *IMPAudioServerMediaSubsession::createNewStreamSource(unsigned clie
     return nullptr;
   }
 
+  if (global_audio[audioChn]->msgChannel) {
+    global_audio[audioChn]->msgChannel->clear();
+  }
   FramedSource *audioSourceReplica = replicator->createStreamReplica();
   if (audioSourceReplica) {
     global_audio[audioChn]->rtsp_client_count.fetch_add(1, std::memory_order_relaxed);

--- a/src/IMPDeviceSource.cpp
+++ b/src/IMPDeviceSource.cpp
@@ -1,7 +1,31 @@
 #include "IMPDeviceSource.hpp"
 #include "GroupsockHelper.hh"
+#include <cstring>
 #include <iostream>
 #include <type_traits>
+
+static inline int64_t tv_to_us(const struct timeval &tv) {
+  return static_cast<int64_t>(tv.tv_sec) * 1000000LL + static_cast<int64_t>(tv.tv_usec);
+}
+
+static inline struct timeval us_to_tv(int64_t us) {
+  struct timeval tv;
+  tv.tv_sec = static_cast<time_t>(us / 1000000LL);
+  tv.tv_usec = static_cast<suseconds_t>(us % 1000000LL);
+  if (tv.tv_usec < 0) {
+    tv.tv_sec -= 1;
+    tv.tv_usec += 1000000;
+  }
+  return tv;
+}
+
+static inline bool is_plausible_wallclock_tv(const struct timeval &tv) {
+  if (tv.tv_usec < 0 || tv.tv_usec >= 1000000) {
+    return false;
+  }
+  constexpr time_t kMinUnixTime = 946684800; // 2000-01-01
+  return tv.tv_sec >= kMinUnixTime;
+}
 
 // explicit instantiation
 template class IMPDeviceSource<H264NALUnit, video_stream>;
@@ -56,7 +80,7 @@ template <typename FrameType, typename Stream> void IMPDeviceSource<FrameType, S
   }
 
   FrameType nal;
-  if (stream->msgChannel->read(&nal)) {
+  while (stream->msgChannel->read(&nal)) {
     if (nal.data.size() > fMaxSize) {
       fFrameSize = fMaxSize;
       fNumTruncatedBytes = nal.data.size() - fMaxSize;
@@ -68,15 +92,40 @@ template <typename FrameType, typename Stream> void IMPDeviceSource<FrameType, S
        steady +1024 RTP PTS increments and avoid gettimeofday jitter. */
     if constexpr (std::is_same_v<FrameType, AudioFrame>) {
       auto *imp_audio = global_audio[encChn]->imp_audio;
-      if (imp_audio && imp_audio->format == IMPAudioFormat::AAC) {
+      bool use_aac_clock = false;
+      int sampleRate = 16000;
+      if (cfg && cfg->audio.input_sample_rate > 0) {
+        sampleRate = cfg->audio.input_sample_rate;
+      }
+      if (imp_audio) {
+        use_aac_clock = (imp_audio->format == IMPAudioFormat::AAC);
+        if (imp_audio->sample_rate > 0) {
+          sampleRate = imp_audio->sample_rate;
+        }
+      } else if (cfg && cfg->audio.input_format && std::strcmp(cfg->audio.input_format, "AAC") == 0) {
+        // During transient audio restarts, keep AAC timing behavior stable.
+        use_aac_clock = true;
+      }
+
+      bool has_audio_time = is_plausible_wallclock_tv(nal.time);
+      if (has_audio_time) {
+        fPresentationTime = nal.time;
+      } else if (use_aac_clock) {
         if (audioFirstFrame) {
           gettimeofday(&audioStartTime, NULL);
           audioFrameCount = 0;
+          audioClockSampleRate = sampleRate;
           audioFirstFrame = false;
+        } else if (audioClockSampleRate <= 0 && sampleRate > 0) {
+          audioClockSampleRate = sampleRate;
         }
-        int sampleRate = (imp_audio->sample_rate > 0) ? imp_audio->sample_rate : 16000;
+        int effectiveSampleRate = (audioClockSampleRate > 0) ? audioClockSampleRate : sampleRate;
+        if (effectiveSampleRate <= 0) {
+          effectiveSampleRate = 16000;
+        }
         constexpr uint64_t kSamplesPerFrame = 1024;
-        uint64_t usec_offset = (audioFrameCount * kSamplesPerFrame * 1000000ULL) / static_cast<uint64_t>(sampleRate);
+        uint64_t usec_offset =
+            (audioFrameCount * kSamplesPerFrame * 1000000ULL) / static_cast<uint64_t>(effectiveSampleRate);
         fPresentationTime.tv_sec  = audioStartTime.tv_sec  + static_cast<time_t>(usec_offset / 1000000ULL);
         fPresentationTime.tv_usec = audioStartTime.tv_usec + static_cast<suseconds_t>(usec_offset % 1000000ULL);
         if (fPresentationTime.tv_usec >= 1000000) {
@@ -87,53 +136,96 @@ template <typename FrameType, typename Stream> void IMPDeviceSource<FrameType, S
       } else {
         gettimeofday(&fPresentationTime, NULL);
       }
+
+      int64_t pts_us = tv_to_us(fPresentationTime);
+      int rate_for_tick = sampleRate > 0 ? sampleRate : 16000;
+      int64_t min_audio_step_us = (1000000LL + rate_for_tick - 1) / rate_for_tick;
+      if (use_aac_clock) {
+        min_audio_step_us = (1024LL * 1000000LL + rate_for_tick - 1) / rate_for_tick;
+      }
+      if (min_audio_step_us < 1) {
+        min_audio_step_us = 1;
+      }
+      if (audioLastPtsUs >= 0) {
+        int64_t delta_pts_us = pts_us - audioLastPtsUs;
+        int64_t max_forward_jump_us = 1000000LL;
+        if (use_aac_clock && min_audio_step_us > 0) {
+          int64_t aac_jump_limit = min_audio_step_us * 120;
+          if (aac_jump_limit > max_forward_jump_us) {
+            max_forward_jump_us = aac_jump_limit;
+          }
+        }
+        if (delta_pts_us <= 0 || delta_pts_us > max_forward_jump_us) {
+          pts_us = audioLastPtsUs + min_audio_step_us;
+          fPresentationTime = us_to_tv(pts_us);
+        }
+      }
+      audioLastPtsUs = pts_us;
     } else {
-      // Video: use encoder timestamps for stable, jitter-free PTS.
-      // The IMP encoder provides a monotonic microsecond timestamp per NAL.
-      // We anchor it to wall-clock at the first frame, then derive all
-      // subsequent presentation times from the encoder's own clock.
-      if (videoFirstFrame) {
-        gettimeofday(&videoBaseTime, NULL);
-        videoFirstImpTs = nal.imp_ts;
-        videoFirstFrame = false;
+      if (is_plausible_wallclock_tv(nal.time)) {
+        fPresentationTime = nal.time;
+      } else {
+        // Video fallback path for sources that don't provide explicit timeval.
+        int64_t nominal_step_us = 33333;
+        if (stream && stream->stream && stream->stream->fps > 0) {
+          nominal_step_us = 1000000LL / stream->stream->fps;
+        }
+        if (nominal_step_us < 12) {
+          nominal_step_us = 12;
+        }
+        if (videoFirstFrame) {
+          gettimeofday(&videoBaseTime, NULL);
+          videoFirstImpTs = nal.imp_ts;
+          videoFirstFrame = false;
+        }
+
+        int64_t delta_us = nal.imp_ts - videoFirstImpTs;
+
+        bool needs_reanchor = delta_us < 0;
+        if (!needs_reanchor && videoLastDelta >= 0) {
+          int64_t step = delta_us - videoLastDelta;
+          needs_reanchor = (step > 2000000LL) || (step < -500000LL);
+        }
+        if (needs_reanchor) {
+          int64_t target_delta = (videoLastDelta >= 0) ? (videoLastDelta + nominal_step_us) : 0;
+          videoFirstImpTs = nal.imp_ts - target_delta;
+          delta_us = target_delta;
+        } else if (videoLastDelta >= 0 && delta_us <= videoLastDelta) {
+          delta_us = videoLastDelta + 12;
+        }
+        videoLastDelta = delta_us;
+        fPresentationTime.tv_sec  = videoBaseTime.tv_sec  + static_cast<time_t>(delta_us / 1000000LL);
+        fPresentationTime.tv_usec = videoBaseTime.tv_usec + static_cast<suseconds_t>(delta_us % 1000000LL);
+        if (fPresentationTime.tv_usec >= 1000000) {
+          fPresentationTime.tv_sec++;
+          fPresentationTime.tv_usec -= 1000000;
+        }
       }
-      int64_t delta_us = nal.imp_ts - videoFirstImpTs;
-      // Re-anchor on negative delta (wrap/reset) or any step > 2s relative to
-      // the previous frame — forward (encoder uptime jump) or backward (encoder
-      // counter reset that doesn't go below the anchor).
-      bool needs_reanchor = delta_us < 0;
-      if (!needs_reanchor && videoLastDelta >= 0) {
-        int64_t step = delta_us - videoLastDelta;
-        needs_reanchor = (step > 2000000LL) || (step < -500000LL);
+
+      int64_t pts_us = tv_to_us(fPresentationTime);
+      int64_t min_video_step_us = 12;
+      if (stream && stream->stream && stream->stream->fps > 0) {
+        min_video_step_us = 1000000LL / stream->stream->fps;
+        if (min_video_step_us < 12) {
+          min_video_step_us = 12;
+        }
       }
-      if (needs_reanchor) {
-        gettimeofday(&videoBaseTime, NULL);
-        videoFirstImpTs = nal.imp_ts;
-        delta_us = 0;
-      } else if (videoLastDelta >= 0 && delta_us <= videoLastDelta) {
-        // Clamp small backward jitter (<500ms) to keep PTS strictly
-        // monotonically increasing.  The <= also handles the SPS/PPS/IDR
-        // triplet where all three NALs share the same imp_ts (delta_us ==
-        // videoLastDelta): each gets nudged forward by one 90 kHz tick
-        // (≈11 µs) so the RTP sender never emits two packets with the
-        // same timestamp.
-        delta_us = videoLastDelta + 12;
+      if (videoLastPtsUs >= 0) {
+        int64_t delta_pts_us = pts_us - videoLastPtsUs;
+        if (delta_pts_us <= 0 || delta_pts_us > 2000000LL) {
+          pts_us = videoLastPtsUs + min_video_step_us;
+          fPresentationTime = us_to_tv(pts_us);
+        }
       }
-      videoLastDelta = delta_us;
-      fPresentationTime.tv_sec  = videoBaseTime.tv_sec  + static_cast<time_t>(delta_us / 1000000LL);
-      fPresentationTime.tv_usec = videoBaseTime.tv_usec + static_cast<suseconds_t>(delta_us % 1000000LL);
-      if (fPresentationTime.tv_usec >= 1000000) {
-        fPresentationTime.tv_sec++;
-        fPresentationTime.tv_usec -= 1000000;
-      }
+      videoLastPtsUs = pts_us;
     }
 
     memcpy(fTo, &nal.data[0], fFrameSize);
 
     if (fFrameSize > 0) {
       FramedSource::afterGetting(this);
+      return;
     }
-  } else {
-    fFrameSize = 0;
   }
+  fFrameSize = 0;
 }

--- a/src/IMPDeviceSource.hpp
+++ b/src/IMPDeviceSource.hpp
@@ -34,11 +34,14 @@ private:
   bool audioFirstFrame{true};
   struct timeval audioStartTime{};
   uint64_t audioFrameCount{0};
+  int audioClockSampleRate{0};
+  int64_t audioLastPtsUs{-1};
 
   // Video encoder timestamp tracking (avoids gettimeofday jitter)
   bool videoFirstFrame{true};
   int64_t videoFirstImpTs{0};
   int64_t videoLastDelta{-1};
+  int64_t videoLastPtsUs{-1};
   struct timeval videoBaseTime{};
 };
 

--- a/src/IMPEncoder.cpp
+++ b/src/IMPEncoder.cpp
@@ -39,7 +39,6 @@ IMPEncoder *IMPEncoder::createNew(_stream *stream, int encChn, int encGrp, const
 void IMPEncoder::flush(int encChn) {
   LOG_DDEBUG("flush(" << encChn << ")");
   IMP_Encoder_RequestIDR(encChn);
-  IMP_Encoder_FlushStream(encChn);
 }
 
 void MakeTables(int q, uint8_t *lqt, uint8_t *cqt) {

--- a/src/IMPServerMediaSubsession.hpp
+++ b/src/IMPServerMediaSubsession.hpp
@@ -33,14 +33,19 @@ protected:
                            void *rtcpRRHandlerClientData, unsigned short &rtpSeqNum, unsigned &rtpTimestamp,
                            ServerRequestAlternativeByteHandler *serverRequestAlternativeByteHandler,
                            void *serverRequestAlternativeByteHandlerClientData) override {
-    OnDemandServerMediaSubsession::startStream(clientSessionId, streamToken, rtcpRRHandler, rtcpRRHandlerClientData,
-                                               rtpSeqNum, rtpTimestamp, serverRequestAlternativeByteHandler,
-                                               serverRequestAlternativeByteHandlerClientData);
-
-    global_rtsp_clients.fetch_add(1, std::memory_order_relaxed);
+    // Drop any stale queued NAL units so a new client starts from a fresh IDR
+    // timeline and does not see pre-flush timestamp history.
+    if (encChn >= 0 && encChn < NUM_VIDEO_CHANNELS && global_video[encChn] && global_video[encChn]->msgChannel) {
+      global_video[encChn]->msgChannel->clear();
+    }
     // request idr frame every second for the next x seconds
     global_video[encChn]->idr_fix = 5;
     IMPEncoder::flush(encChn);
+
+    OnDemandServerMediaSubsession::startStream(clientSessionId, streamToken, rtcpRRHandler, rtcpRRHandlerClientData,
+                                               rtpSeqNum, rtpTimestamp, serverRequestAlternativeByteHandler,
+                                               serverRequestAlternativeByteHandlerClientData);
+    global_rtsp_clients.fetch_add(1, std::memory_order_relaxed);
   }
 
   virtual void deleteStream(unsigned clientSessionId, void *&streamToken) override {

--- a/src/VideoWorker.cpp
+++ b/src/VideoWorker.cpp
@@ -70,6 +70,12 @@ void VideoWorker::run() {
   int last_mp4_fps = (video_state && video_state->stream) ? video_state->stream->fps : 0;
   int64_t mp4_frame_switch_threshold = compute_frame_switch_threshold(last_mp4_fps);
 
+  int64_t ts_last_nonzero = 0;
+  int64_t ts_last_frame = 0;
+  int64_t ts_last_rtp = 0;
+  int64_t ts_current_frame = 0;
+  bool ts_have_current_frame = false;
+
   auto reset_mp4_sample = [&]() {
     mp4_sample.clear();
     mp4_sample_is_key = false;
@@ -275,10 +281,18 @@ void VideoWorker::run() {
           continue;
         }
 
-        int64_t nal_ts = stream.pack[stream.packCount - 1].timestamp;
-        struct timeval encoder_time;
-        encoder_time.tv_sec = nal_ts / 1000000;
-        encoder_time.tv_usec = nal_ts % 1000000;
+        if (stream.packCount == 0) {
+          IMP_Encoder_ReleaseStream(encChn, &stream);
+          continue;
+        }
+
+        int64_t nominal_frame_step_us = 33333;
+        if (video_state && video_state->stream && video_state->stream->fps > 0) {
+          nominal_frame_step_us = 1000000LL / video_state->stream->fps;
+        }
+        if (nominal_frame_step_us < 1000) {
+          nominal_frame_step_us = 1000;
+        }
 
         for (uint32_t i = 0; i < stream.packCount; ++i) {
           bool recorder_active = channel_recorder.isActive();
@@ -296,6 +310,67 @@ void VideoWorker::run() {
           uint8_t *start = hal::encoder::get_pack_data_start(stream, i);
           uint32_t length = hal::encoder::get_pack_data_length(stream, i);
           uint8_t *end = start + length;
+          bool frame_start = (i == 0) || stream.pack[i - 1].frameEnd;
+          if (frame_start) {
+            uint32_t frame_end_idx = i;
+            while (frame_end_idx + 1 < stream.packCount && !stream.pack[frame_end_idx].frameEnd) {
+              ++frame_end_idx;
+            }
+
+            int64_t frame_ts = 0;
+            for (uint32_t j = i; j <= frame_end_idx; ++j) {
+              if (stream.pack[j].timestamp > 0) {
+                frame_ts = stream.pack[j].timestamp;
+              }
+            }
+
+            if (frame_ts > 0) {
+              if (frame_ts > ts_last_nonzero) {
+                ts_last_nonzero = frame_ts;
+              } else {
+                frame_ts = ts_last_nonzero;
+              }
+            } else if (ts_last_nonzero > 0) {
+              frame_ts = ts_last_nonzero;
+            } else if (ts_last_frame > 0) {
+              frame_ts = ts_last_frame + nominal_frame_step_us;
+            }
+
+            if (ts_last_frame > 0 && frame_ts <= ts_last_frame) {
+              frame_ts = ts_last_frame + nominal_frame_step_us;
+            }
+            if (frame_ts <= 0) {
+              frame_ts = (ts_last_frame > 0) ? (ts_last_frame + nominal_frame_step_us) : nominal_frame_step_us;
+            }
+
+            ts_current_frame = frame_ts;
+            ts_have_current_frame = true;
+          }
+
+          int64_t pack_ts = stream.pack[i].timestamp;
+          if (pack_ts > ts_last_nonzero) {
+            ts_last_nonzero = pack_ts;
+          }
+          if (ts_have_current_frame && ts_current_frame > 0) {
+            pack_ts = ts_current_frame;
+          } else if (pack_ts <= 0 && ts_last_nonzero > 0) {
+            pack_ts = ts_last_nonzero;
+          }
+
+          if (stream.pack[i].frameEnd && pack_ts > 0) {
+            ts_last_frame = pack_ts;
+          }
+
+          int64_t rtsp_ts = pack_ts;
+          if (rtsp_ts <= 0) {
+            rtsp_ts = (ts_last_rtp > 0) ? (ts_last_rtp + nominal_frame_step_us) : nominal_frame_step_us;
+          }
+          constexpr int64_t kMinRtpStepUs = 12;
+          if (ts_last_rtp > 0 && rtsp_ts <= ts_last_rtp) {
+            rtsp_ts = ts_last_rtp + kMinRtpStepUs;
+          }
+          ts_last_rtp = rtsp_ts;
+
           uint32_t h264_nal = hal::encoder::get_h264_nal_type(stream.pack[i]);
           uint32_t h265_nal = hal::encoder::get_h265_nal_type(stream.pack[i]);
 
@@ -369,11 +444,10 @@ void VideoWorker::run() {
           }
 
           if ((nal_is_idr || nal_is_hevc_idr) && video_state) {
-            video_state->mp4_last_idr_ts.store(stream.pack[i].timestamp, std::memory_order_relaxed);
+            video_state->mp4_last_idr_ts.store(pack_ts, std::memory_order_relaxed);
           }
 
           if (recorder_accepts_samples && payload_len > 0 && !(nal_is_vps || nal_is_sps || nal_is_pps)) {
-            int64_t pack_ts = stream.pack[i].timestamp;
             bool pack_frame_end = stream.pack[i].frameEnd;
 
             if (mp4_sample_ts != -1 && !mp4_sample.empty()) {
@@ -437,10 +511,9 @@ void VideoWorker::run() {
           if (global_video[encChn]->hasDataCallback) {
             H264NALUnit nalu;
 
-            // Use the frame-level timestamp (from last pack) for all NALs
-            // in this GetStream() call.  SPS/PPS packs may carry timestamp=0
-            // which would cause a DTS discontinuity in the RTP stream.
-            nalu.imp_ts = nal_ts;
+            nalu.imp_ts = rtsp_ts;
+            nalu.time.tv_sec = static_cast<time_t>(rtsp_ts / 1000000LL);
+            nalu.time.tv_usec = static_cast<suseconds_t>(rtsp_ts % 1000000LL);
 
             // We use start+4 because the encoder inserts 4-byte MPEG
             // 'startcodes' at the beginning of each NAL. Live555 complains.
@@ -448,13 +521,13 @@ void VideoWorker::run() {
 
             // Add frame boundary metadata for complete frame detection
             static uint32_t frame_counter = 0;
-            if (i == 0) {
+            if (frame_start) {
               frame_counter++;  // New frame starting
             }
             nalu.frame_id = frame_counter;
             nalu.packet_index = i;
             nalu.packet_count = stream.packCount;
-            nalu.is_frame_start = (i == 0);
+            nalu.is_frame_start = frame_start;
             nalu.is_frame_end = stream.pack[i].frameEnd;
 
             if (global_video[encChn]->idr == false) {

--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -23,7 +23,7 @@
 #include <mutex>
 #include <vector>
 
-#define MSG_CHANNEL_SIZE 20
+#define MSG_CHANNEL_SIZE 200
 #define BACKCHANNEL_QUEUE_SIZE 200
 #define AUDIO_OUTPUT_QUEUE_SIZE 64
 #define NUM_AUDIO_CHANNELS 1
@@ -76,6 +76,7 @@ struct H264NALUnit {
   uint32_t packet_index = 0;        // Position within frame (0-based)
   uint32_t packet_count = 0;        // Total NAL units in frame
 
+  struct timeval time{0, 0};
   // Encoder timestamp in microseconds (from IMP encoder, monotonic)
   int64_t imp_ts = 0;
 };


### PR DESCRIPTION
## Summary
- harden audio/video timestamp handling to prevent severe RTSP PTS/DTS jumps
- enforce AAC frame-duration based monotonic progression and wallclock plausibility guards
- improve video frame boundary metadata handling and startup robustness

## Validation
- rebuilt package repeatedly on wyze_cam3_t31x_gc2053_atbm6031
- repeated ffprobe/ffmpeg/mpv runtime checks against camera RTSP stream
- severe audio reset/desync regression no longer reproduced in tests