### PR TITLE
Ensure there's no dangling timer after BackchannelSink is destroyed

### DIFF
--- a/src/BackchannelSink.cpp
+++ b/src/BackchannelSink.cpp
@@ -37,7 +37,7 @@ BackchannelSink::BackchannelSink(UsageEnvironment &env, unsigned clientSessionId
 }
 
 BackchannelSink::~BackchannelSink() {
-  sendBackchannelStopFrame();
+  stopPlaying();
   delete[] fReceiveBuffer;
 }
 


### PR DESCRIPTION
The BackchannelSink schedules a timer to check for timeouts. The method stopPlaying removes the timer but it was never called, so the timer could be called on an already destroyed instance, which in turn made any connection after the first one non functional and eventually it would cause a segmentation fault.
I added a call to stopPlaying in the destructor, instead of calling sendBackchannelStopFrame (which is already called by stopPlaying)