### PR TITLE
h265: fix RTP marker bit and SDP fmtp sprop-parameter-sets

### DIFF
--- a/src/simple-rtsp/RtpPacketizer.cpp
+++ b/src/simple-rtsp/RtpPacketizer.cpp
@@ -98,9 +98,13 @@ bool packetizeH265(const uint8_t *nalData, size_t nalLen,
     if (!nalData || nalLen < 2) return true;
 
     uint8_t nalType = (nalData[0] >> 1) & 0x3F;
+    // HEVC NAL types 0-31 are VCL (slice) units; 32+ are VPS/SPS/PPS/SEI/etc.
+    // Only a slice may legitimately be the last NAL of an access unit, so
+    // only slice types should ever carry the RTP marker bit.
+    bool isVcl = nalType <= 31;
 
     if (nalLen <= static_cast<size_t>(RTP_MAX_PAYLOAD)) {
-        bool marker = isLastFrame;
+        bool marker = isLastFrame && isVcl;
         return sendOne(nalData, nalLen, payloadType, marker, state, output);
     }
 
@@ -115,7 +119,7 @@ bool packetizeH265(const uint8_t *nalData, size_t nalLen,
                                 static_cast<size_t>(RTP_MAX_PAYLOAD - 3));
         bool start = (offset == 0);
         bool end   = (offset + chunk >= fragLen);
-        bool marker = isLastFrame && end;
+        bool marker = isLastFrame && end && isVcl;
 
         uint8_t fuBuf[RTP_MAX_PAYLOAD];
         fuBuf[0] = fuIndicator;

--- a/src/simple-rtsp/SdpGenerator.cpp
+++ b/src/simple-rtsp/SdpGenerator.cpp
@@ -106,25 +106,34 @@ std::string generateSdp(const VideoStreamConfig &video,
 
     if (video.haveCodecConfig && !video.sps.empty()) {
         if (isH265) {
-            // H.265: fmtp with profile-tier-level (RFC 7798 §7.1 mandatory)
-            // followed by sprop-vps, sprop-sps, sprop-pps
+            // H.265: fmtp with profile-tier-level plus sprop-vps/sprop-sps/
+            // sprop-pps, all as parameters of the SAME a=fmtp line (RFC 7798
+            // §7.1) -- not as separate standalone a=sprop-* lines, which
+            // strict SDP parsers (e.g. go2rtc) don't recognize as part of
+            // the fmtp attribute and silently drop.
             int profSpace = 0, tierFlag = 0, profIdc = 1, levelIdc = 90;
             if (!video.vps.empty())
                 parseVpsProfileTier(video.vps, profSpace, tierFlag, profIdc, levelIdc);
 
             off += snprintf(buf + off, sizeof(buf) - off,
                 "a=fmtp:%d profile-space=%d;tier-flag=%d;"
-                "profile-id=%d;level-id=%d\r\n",
+                "profile-id=%d;level-id=%d",
                 pt, profSpace, tierFlag, profIdc, levelIdc);
 
             if (!video.vps.empty()) {
                 off += snprintf(buf + off, sizeof(buf) - off,
-                    "a=sprop-vps=%s\r\n",
+                    ";sprop-vps=%s",
                     base64Encode(video.vps.data(), video.vps.size()).c_str());
             }
             off += snprintf(buf + off, sizeof(buf) - off,
-                "a=sprop-sps=%s\r\n",
+                ";sprop-sps=%s",
                 base64Encode(video.sps.data(), video.sps.size()).c_str());
+            if (!video.pps.empty()) {
+                off += snprintf(buf + off, sizeof(buf) - off,
+                    ";sprop-pps=%s",
+                    base64Encode(video.pps.data(), video.pps.size()).c_str());
+            }
+            off += snprintf(buf + off, sizeof(buf) - off, "\r\n");
         } else {
             // H.264: fmtp with packetization-mode=1 (required for FU-A)
             std::string profileLevelId;
@@ -148,12 +157,6 @@ std::string generateSdp(const VideoStreamConfig &video,
                 "a=fmtp:%d packetization-mode=1;profile-level-id=%s;"
                 "sprop-parameter-sets=%s\r\n",
                 pt, profileLevelId.c_str(), sprop.c_str());
-        }
-        // PPS for H.265
-        if (isH265 && !video.pps.empty()) {
-            off += snprintf(buf + off, sizeof(buf) - off,
-                "a=sprop-pps=%s\r\n",
-                base64Encode(video.pps.data(), video.pps.size()).c_str());
         }
     }
 


### PR DESCRIPTION
## Summary
- `packetizeH265()` set the RTP marker bit from `isLastFrame` alone, with no check on NAL type, unlike the H.264 packetizer. If a non-VCL NAL (VPS/SPS/PPS/SEI) ever ends up as the last pack in an `IMP_Encoder_GetStream` batch, it gets marked instead of the actual slice. Marker-driven RTP consumers (e.g. go2rtc's native HEVC depacketizer) then flush an access unit at the wrong boundary, producing corrupted decode (`PPS id out of range`, garbled frames). ffmpeg-based consumers don't notice, since they detect access-unit boundaries via timestamp changes instead.
- `generateSdp()` emitted `sprop-vps`/`sprop-sps`/`sprop-pps` for H.265 as standalone `a=sprop-vps=...` / `a=sprop-sps=...` / `a=sprop-pps=...` SDP lines instead of as parameters of the `a=fmtp:` line, which RFC 7798 §7.1 requires. Strict SDP parsers (go2rtc's included) only read the actual `a=fmtp:` line and never see this sprop data at all. go2rtc's H.265 SPS lookup then comes back empty and it falls back to a hardcoded placeholder SPS to build the MP4 init segment for MSE playback -- that placeholder decodes to 2560x1440 regardless of the camera's real resolution, so browsers render a correctly-decoded picture squeezed into the corner of a wrongly-sized frame. Wrapping the go2rtc source in ffmpeg masks it (ffmpeg gets real parameter sets from in-band NALs instead), but that's not viable for cameras needing RTSP backchannel.

Both were found while tracking down broken H.265 playback specifically through go2rtc on a downstream Thingino build; each is independently reproducible and independently root-caused (see individual commit messages).

## Test plan
- [x] Applied cleanly against `feature/backchannel` tip
- [x] Built and flashed on real T31 hardware (Thingino downstream); confirmed go2rtc restream + browser MSE playback fixed after both fixes
- [x] Manually decoded the SDP-fallback placeholder SPS to confirm it corresponds exactly to the observed 2560x1440 misreported dimensions