### PR TITLE
fix: serve RTSP sessions that subscribed to the audio track only

### DIFF
--- a/src/network/rtsp/RtspServer.cpp
+++ b/src/network/rtsp/RtspServer.cpp
@@ -2427,9 +2427,11 @@ void RtspServer::sendRtcpSr(Session &s) {
     if (!s.tcpInterleaved) {
         // UDP: send via UDP sockets
         sockaddr_in target = s.clientAddr;
-        target.sin_port = htons(s.videoClientRtcpPort);
-        sendto(s.videoRtcpSock, rtcp, sizeof(rtcp), MSG_DONTWAIT,
-               (sockaddr *)&target, sizeof(target));
+        if (s.videoSetupUrl[0] != '\0') {
+            target.sin_port = htons(s.videoClientRtcpPort);
+            sendto(s.videoRtcpSock, rtcp, sizeof(rtcp), MSG_DONTWAIT,
+                   (sockaddr *)&target, sizeof(target));
+        }
         if (s.hasAudio) {
             uint32_t asrc = htonl(s.audioRtp.ssrc);
             memcpy(rtcp + 4, &asrc, 4);
@@ -2465,7 +2467,8 @@ void RtspServer::sendRtcpSr(Session &s) {
             s.sendQueue.push_back(std::move(pkt));
             s.sendQueueBytes += remain;
         };
-        queueTc(s.videoInterleavedRtcp, rtcp, 28);
+        if (s.videoSetupUrl[0] != '\0')
+            queueTc(s.videoInterleavedRtcp, rtcp, 28);
         if (s.hasAudio) {
             uint32_t asrc = htonl(s.audioRtp.ssrc);
             memcpy(rtcp + 4, &asrc, 4);

--- a/src/network/rtsp/RtspServer.cpp
+++ b/src/network/rtsp/RtspServer.cpp
@@ -226,7 +226,8 @@ void RtspServer::eventLoop() {
         // -- Drain taps for playing sessions -----------------------------
         for (auto &s : sessions_) {
             if (!s || !s->playing) continue;
-            if (s->videoChn < 0 && !s->audioOnly && !s->backchannel) continue;
+            if (s->videoChn < 0 && !s->hasAudio && !s->audioOnly &&
+                !s->backchannel && !s->hasSubtitles) continue;
 
             bool backpressure = false;
 


### PR DESCRIPTION
An RTSP client that subscribes to **only the audio track** of `/ch0` never receives
a single audio RTP packet. `PLAY` returns `200 OK`, RTCP flows, and then nothing.

The drain loop in `eventLoop()` skips it:

```c
if (s->videoChn < 0 && !s->audioOnly && !s->backchannel) continue;
```

Such a session has `videoChn < 0` (no `track1` SETUP), `audioOnly == false`
(that flag is set per *endpoint*, only for `rtsp.audio_only_endpoint`, i.e.
`/mic`) and `backchannel == false` — so its `audioTap` is never drained.
`handlePlay()` disagrees: its own guard includes `hasAudio`, and it registers
the audio tap for exactly these sessions. Commit 1 mirrors that guard.

Commit 2 fixes a second defect on the same path, found while investigating:
`sendRtcpSr()` also emits a *video* SR on `videoInterleavedRtcp`, which for an
audio-only session still holds its default of channel 1 — the channel the client
mapped to audio RTCP. The client sees Sender Reports from two SSRCs on one
channel, one with an unset video RTP timestamp.

### Measured on a Cinnado D1 (T23N, SC2336), thingino `ciao+01110e3`

| Subscription | audio RTP | result |
|---|---|---|
| `track2` only, before | **0** in 25 s | 512 bytes, RTCP only |
| `track2` only, after | **712** in 15 s | first packet 0.03 s after PLAY |
| `track1`+`track2` | 637 in 12 s | unaffected by either commit |

Distinct SSRCs on the audio RTCP channel: 2 before, 1 after.

Requesting a subset of tracks is legal RTSP (RFC 2326 aggregate control) and is
what a client should do when it only wants audio, rather than pulling a second
copy of the 1080p video for ~16 kbit/s of AAC.

### Why it matters in practice

tinyCam Monitor's ONVIF path opens one video-only session and one audio-only
session. The audio-only one got nothing, so the app's probe timed out after
~20 s, then it fell back to a **second full video+audio** session. Net effect:
audio took ~40 s or more to start, and the camera then encoded and shipped
1080p **twice** — measured 375 KB/s + 393 KB/s to a single phone — for the rest
of the session. After these commits it is one video stream plus ~16 KB/s of
audio.

### Verification

Both commits are running on the camera in a rebuilt `ciao` image (`prudynt-t`
built from this branch via `PRUDYNT_T_OVERRIDE_SRCDIR`, flashed to `mtd4`).
Audio-only, both-tracks and `/mic` subscriptions were all re-tested afterwards.
