### PR TITLE
audio: runtime backchannel codec ordering via audio.backchannel_codec_order

### DIFF
--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -1,4 +1,5 @@
 #include "config/Config.hpp"
+#include "audio/IMPBackchannel.hpp"
 #include "util/Logger.hpp"
 #include "isp/imp_hal.hpp"
 #include <algorithm>
@@ -1154,6 +1155,36 @@ void CFG::load() {
     for (auto &item : floatItems)
       handleConfigItem(jsonConfig, item);
     LOG_DEBUG("CFG::load() - Finished processing config items");
+
+    // -- audio.backchannel_codec_order --------------------------------
+    // Optional string array controlling the order in which backchannel
+    // codecs are offered in the SDP.  Clients commonly pick the first
+    // compatible codec, so the first entry becomes the negotiated
+    // default.  Unknown names and codecs disabled at compile time are
+    // skipped with a warning; empty/missing keeps compile-time order.
+    {
+      JsonValue *orderVal = getNestedValue(jsonConfig, "audio.backchannel_codec_order");
+      if (orderVal && orderVal->type == JSON_ARRAY) {
+        audio.backchannel_codec_order.clear();
+        for (JsonArrayItem *it = orderVal->value.array_head; it;
+             it = it->next) {
+          JsonValue *entry = it->value;
+          if (!entry || entry->type != JSON_STRING || !entry->value.string) continue;
+          // validate against the compile-time codec set
+          bool known = false;
+#define CHECK_BC(EnumName, NameString, PayloadType, Frequency, MimeType)      \
+          if (strcmp(entry->value.string, NameString) == 0) known = true;
+          X_FOREACH_BACKCHANNEL_FORMAT(CHECK_BC)
+#undef CHECK_BC
+          if (known) {
+            audio.backchannel_codec_order.push_back(strdup(entry->value.string));
+          } else {
+            LOG_WARN("audio.backchannel_codec_order: unknown codec \""
+                     << entry->value.string << "\", skipping");
+          }
+        }
+      }
+    }
   }
 
   if (!daynight.loglevel || daynight.loglevel[0] == '\0') {

--- a/src/config/Config.hpp
+++ b/src/config/Config.hpp
@@ -89,6 +89,9 @@ struct _audio {
   int output_sample_rate = 48000;
   int output_vol;
   int output_gain;
+  // Preferred order of backchannel codecs advertised in the SDP.
+  // Empty = compile-time order from X_FOREACH_BACKCHANNEL_FORMAT.
+  std::vector<const char *> backchannel_codec_order;
 #endif
 
 };

--- a/src/network/rtsp/RtspServer.cpp
+++ b/src/network/rtsp/RtspServer.cpp
@@ -88,6 +88,30 @@ void RtspServer::enableBackchannel() {
     backchannelFormats_.push_back({NameString, Frequency, PayloadType});
     X_FOREACH_BACKCHANNEL_FORMAT(ADD_BC)
 #undef ADD_BC
+
+    // Reorder per audio.backchannel_codec_order.  Clients commonly
+    // pick the first compatible codec, so the first entry effectively
+    // becomes the negotiated default.  Codecs missing from the list
+    // keep their compile-time relative order after the listed ones.
+    if (!cfg->audio.backchannel_codec_order.empty()) {
+        std::vector<BackchannelConfig> ordered;
+        ordered.reserve(backchannelFormats_.size());
+        for (const char *want : cfg->audio.backchannel_codec_order) {
+            for (auto it = backchannelFormats_.begin();
+                 it != backchannelFormats_.end(); ++it) {
+                if (it->codec == want) {
+                    ordered.push_back(*it);
+                    backchannelFormats_.erase(it);
+                    break;
+                }
+            }
+        }
+        ordered.insert(ordered.end(), backchannelFormats_.begin(),
+                       backchannelFormats_.end());
+        backchannelFormats_ = std::move(ordered);
+        LOG_INFO("Backchannel codec order overridden by config");
+    }
+
     backchannelEnabled_ = true;
     LOG_INFO("Backchannel enabled: " << backchannelFormats_.size() << " codecs");
 }


### PR DESCRIPTION
## Problem

Clients commonly negotiate the **first compatible** backchannel codec from the SDP offer, so offer order effectively decides the default codec for most talkback clients. The compile-time X-macro order (AAC first on full builds) is not what every integrator wants, and the codec list was previously compile-time only — no runtime customization possible.

## Solution

New optional `prudynt.json` key:

```json
"audio": {
  "backchannel_codec_order": ["PCMU", "PCMA", "AAC", "OPUS"]
}
```

- Listed codecs are advertised first in SDP m= line, rtpmap, SETUP matching, and ANNOUNCE negotiation order
- First list entry implicitly becomes the default `[0]` codec — no separate "preferred" key
- Unknown names: warning + skip. Compile-disabled codecs: silently ignored (validation runs against the compile-time set)
- Codecs absent from the list keep their compile-time relative order **after** the listed ones
- Missing/empty key: exact compile-time order — **zero behavior change by default**

## Implementation

The vector `backchannelFormats_` is the single chokepoint — SDP generation, SETUP matching, and ANNOUNCE negotiation all iterate it in order, so only its ordering needs to change:

- `Config.hpp`: `std::vector<const char *> backchannel_codec_order` in `_audio`
- `Config.cpp`: parse the array in `CFG::load()` after the generic items; validate each name against `X_FOREACH_BACKCHANNEL_FORMAT` before storing (`strdup`, matching existing char-item handling)
- `RtspServer.cpp`: `enableBackchannel()` expands the X-macro as today, then stable-partitions the vector per the config list

The X-macro remains the single source of truth for codec properties (PT, clock, mime); only ordering comes from config.

## Usage

Runtime editable per camera:

```
jct /etc/prudynt.json set audio.backchannel_codec_order '["PCMU","AAC"]'
service restart prudynt
```

A build-time alternative (reordering the X-macro via CFLAGS) was considered and rejected: combinatorially ugly and not per-camera configurable.

Requested by Josh (WLTechBlog).
