### PR TITLE
recording: unblock live frames when recorder fails to start; cap pending queue

### DIFF
--- a/src/recording/MP4ControlSocket.cpp
+++ b/src/recording/MP4ControlSocket.cpp
@@ -817,6 +817,14 @@ bool start_recording(const std::string &path, int target_channel) {
   } else {
     reset_wait_state();
     disable_force_if_idle();
+#ifdef PREBUFFER_ENABLED
+    // Recorder failed to start: unblock live frame writing. If the flag
+    // stays set, VideoWorker queues every incoming frame into
+    // pending_frames_during_flush without bound, exhausting RAM.
+    video->mp4_prebuffer_flushing.store(false, std::memory_order_release);
+    // Drop queued frames: there is no recorder to hand them to.
+    video->mp4_prebuffer_offset_ms.store(0, std::memory_order_relaxed);
+#endif
   }
   return ok;
 }

--- a/src/video/VideoWorker.cpp
+++ b/src/video/VideoWorker.cpp
@@ -232,6 +232,18 @@ void VideoWorker::run() {
     bool is_keyframe;
   };
   std::vector<PendingFrame> pending_frames_during_flush;
+  // Hard cap on queued frames. The queue is only used while
+  // mp4_prebuffer_flushing is set; a full cap means the flush never
+  // completed (recorder start failed or hung) — drop oldest to protect RAM.
+  static constexpr size_t kMaxPendingFramesDuringFlush = 32;
+  auto enqueue_pending_frame = [&](PendingFrame &&pf) {
+    if (pending_frames_during_flush.size() >=
+        kMaxPendingFramesDuringFlush) {
+      pending_frames_during_flush.erase(
+          pending_frames_during_flush.begin());
+    }
+    pending_frames_during_flush.push_back(std::move(pf));
+  };
   auto compute_frame_switch_threshold = [](int fps_value) -> int64_t {
     int fps = fps_value > 0 ? fps_value : 25;
     int64_t frame_period = 1000000LL / fps;
@@ -313,7 +325,7 @@ void VideoWorker::run() {
       pf.data = std::move(mp4_sample);
       pf.timestamp_us = mp4_sample_ts_us;
       pf.is_keyframe = mp4_sample_is_key;
-      pending_frames_during_flush.push_back(std::move(pf));
+      enqueue_pending_frame(std::move(pf));
 
       reset_mp4_sample();
       mp4_sample_ts_base_us =


### PR DESCRIPTION
## Problem

Reported by a Tapo C200 (stable) user: during motion-event recording to SD, the camera progressively loses function - Web UI config saves fail with "network error when fetching resource", SD card remounts fail, and the system degrades until reboot. RAM exhaustion is visible (36MB total, prudynt grows until fork() fails for CGI scripts).

## Root cause

In `MP4ControlSocket.cpp`, when motion recording starts, `mp4_prebuffer_flushing` is set to `true` *before* `recorder.start()`. If `recorder.start()` **fails** (e.g. SD target unwritable/unmounted), the failure branch calls `reset_wait_state()` + `disable_force_if_idle()` but **never resets `mp4_prebuffer_flushing`**.

`stop_recording()` cannot rescue the state either: it early-returns because `recorder.isActive()` is false (recorder never started).

Meanwhile `VideoWorker` sees the stuck `mp4_prebuffer_flushing == true` and queues **every incoming frame** into `pending_frames_during_flush` - a vector with **no size cap and no timeout**:

At stream bitrate this exhausts RAM within minutes.

## Fix

1. **MP4ControlSocket.cpp**: on `recorder.start()` failure, clear `mp4_prebuffer_flushing` and reset the prebuffer offset so live frame writing resumes immediately.
2. **VideoWorker.cpp**: hard cap `pending_frames_during_flush` at 32 frames (drop-oldest). Even if some unforeseen path leaves the flush stuck, RAM is protected.

## Testing

- Not yet tested on hardware. Reporter (Tapo C200, stable) will validate after merge or via local build.

Fixes the "network error when fetching resource" + SD mount failure + memory exhaustion pattern during motion recording on 36MB-RAM devices.

Reported-by: Tapo C200 user (Discord)
